### PR TITLE
This prevents exceptions, when scanning files having no namespaces.

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -35,6 +35,10 @@ abstract class AbstractSprykerSniff implements \PHP_CodeSniffer_Sniff
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
 
+        if (count($classNameParts) < 3) {
+            return '';
+        }
+
         return $classNameParts[2];
     }
 
@@ -47,6 +51,10 @@ abstract class AbstractSprykerSniff implements \PHP_CodeSniffer_Sniff
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
+
+        if (count($classNameParts) < 4) {
+            return '';
+        }
 
         return $classNameParts[3];
     }


### PR DESCRIPTION
When there is a call definition in a project without a namespace, or just any other folder in the demoshop directory containing code without namespaces the sniffer issues many exceptions. This fix will prevent those.