### PR TITLE
Enable unfunctional InlineAssignment and fix nested false positives.

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -161,16 +161,27 @@ abstract class AbstractSprykerSniff implements \PHP_CodeSniffer_Sniff
      * @param string|array $search
      * @param int $start
      * @param int $end
+     * @param bool $skipNested
      * @return bool
      */
-    protected function contains(\PHP_CodeSniffer_File $phpcsFile, $search, $start, $end)
+    protected function contains(\PHP_CodeSniffer_File $phpcsFile, $search, $start, $end, $skipNested = true)
     {
         $tokens = $phpcsFile->getTokens();
+
         for ($i = $start; $i <= $end; $i++) {
-            if ($tokens[$i]['type'] === 'T_OPEN_PARENTHESIS') {
+            if ($skipNested && $tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
                 $i = $tokens[$i]['parenthesis_closer'];
                 continue;
             }
+            if ($skipNested && $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+            if ($skipNested && $tokens[$i]['code'] === T_OPEN_CURLY_BRACKET) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
             if ($this->isGivenKind($search, $tokens[$i])) {
                 return true;
             }


### PR DESCRIPTION
Without the Sniff suffix it was just not running, and now reports quite a few issues in the core:
```
FILE: .../Zed/Cart/Business/StorageProvider/NonPersistentProviderTest.php
----------------------------------------------------------------------
FOUND 18 ERRORS AFFECTING 18 LINES
----------------------------------------------------------------------
  49 | ERROR | Inline assignment not allowed
  51 | ERROR | Inline assignment not allowed
  75 | ERROR | Inline assignment not allowed
  77 | ERROR | Inline assignment not allowed
 111 | ERROR | Inline assignment not allowed
 112 | ERROR | Inline assignment not allowed
 126 | ERROR | Inline assignment not allowed
 127 | ERROR | Inline assignment not allowed
 146 | ERROR | Inline assignment not allowed
 147 | ERROR | Inline assignment not allowed
 164 | ERROR | Inline assignment not allowed
 166 | ERROR | Inline assignment not allowed
 182 | ERROR | Inline assignment not allowed
 184 | ERROR | Inline assignment not allowed
 200 | ERROR | Inline assignment not allowed
 202 | ERROR | Inline assignment not allowed
 218 | ERROR | Inline assignment not allowed
 220 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...tests/Functional/Spryker/Zed/Sales/Business/TestOrderCreator.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 35 | ERROR | Inline assignment not allowed
 44 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...nit/Spryker/Zed/SalesSplit/Business/Model/OrderItemSplitTest.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 52 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: .../Spryker/Zed/Braintree/Business/Payment/Method/PayPal/PayPal.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 37 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...es/Gui/src/Spryker/Shared/Gui/ProgressBar/ProgressBarBuilder.php
----------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------
 100 | ERROR | Inline assignment not allowed
 101 | ERROR | Inline assignment not allowed
 102 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...ution/Communication/Plugin/Oms/Condition/AbstractCheckPlugin.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 28 | ERROR | Inline assignment not allowed
 29 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...ryker/Zed/Payolution/Business/Payment/Method/Invoice/Invoice.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 61 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...d/Payolution/Business/Payment/Method/Installment/Installment.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 135 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...undles/Oms/src/Spryker/Zed/Oms/Persistence/OmsQueryContainer.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 34 | ERROR | Inline assignment not allowed
 35 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------


FILE: ...ouper/src/Spryker/Zed/ItemGrouper/Business/ItemGrouperFacade.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 41 | ERROR | Inline assignment not allowed
----------------------------------------------------------------------
```
