### PR TITLE
Add SprykerNamespaceSniff.

### DIFF
--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * (c) Spryker Systems GmbH copyright protected.
+ */
+
+namespace Spryker\Sniffs\Namespaces;
+
+use Spryker\Traits\BasicsTrait;
+
+/**
+ * Makes sure the namespace declared in each class file fits to the folder structure.
+ */
+class SprykerNamespaceSniff implements \PHP_CodeSniffer_Sniff
+{
+
+    use BasicsTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        return [T_CLASS];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $namespaceStatement = $this->getNamespaceStatement($phpcsFile);
+        if (!$namespaceStatement || $this->isBlacklistedFile($phpcsFile)) {
+            return;
+        }
+
+        $filename = $phpcsFile->getFilename();
+
+        preg_match('#/(src|tests)/(Spryker|Unit)/(.*)#', $filename, $matches);
+        if (!$matches) {
+            return;
+        }
+
+        $extractedPath = $matches[2] . '/' . $matches[3];
+        $pathWithoutFilename = substr($extractedPath, 0, strrpos($extractedPath, DIRECTORY_SEPARATOR));
+
+        $namespace = $namespaceStatement['namespace'];
+        $pathToNamespace = str_replace(DIRECTORY_SEPARATOR, '\\', $pathWithoutFilename);
+        if ($namespace === $pathToNamespace) {
+            return;
+        }
+
+        $error = sprintf('Namespace `%s` does not fit to folder structure `%s`', $namespace, $pathToNamespace);
+        $phpcsFile->addError($error, $namespaceStatement['start']);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpcsFile
+     *
+     * @return bool
+     */
+    protected function isBlacklistedFile(\PHP_CodeSniffer_File $phpcsFile)
+    {
+        $file = $phpcsFile->getFilename();
+        if (strpos($file, DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR) !== false) {
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -29,13 +29,13 @@ class SprykerNamespaceSniff implements \PHP_CodeSniffer_Sniff
     public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $namespaceStatement = $this->getNamespaceStatement($phpcsFile);
-        if (!$namespaceStatement || $this->isBlacklistedFile($phpcsFile)) {
+        if (!$namespaceStatement) {
             return;
         }
 
         $filename = $phpcsFile->getFilename();
 
-        preg_match('#/(src|tests)/(Spryker|Unit/Spryker|Functional/Spryker)/(.*)#', $filename, $matches);
+        preg_match('#/(src|tests)/(Spryker|Unit/Spryker|Functional/Spryker)/(.+)#', $filename, $matches);
         if (!$matches) {
             return;
         }
@@ -51,21 +51,6 @@ class SprykerNamespaceSniff implements \PHP_CodeSniffer_Sniff
 
         $error = sprintf('Namespace `%s` does not fit to folder structure `%s`', $namespace, $pathToNamespace);
         $phpcsFile->addError($error, $namespaceStatement['start']);
-    }
-
-    /**
-     * @param \PHP_CodeSniffer_File $phpcsFile
-     *
-     * @return bool
-     */
-    protected function isBlacklistedFile(\PHP_CodeSniffer_File $phpcsFile)
-    {
-        $file = $phpcsFile->getFilename();
-        if (strpos($file, DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR) !== false) {
-            return true;
-        }
-
-        return false;
     }
 
 }

--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -35,7 +35,7 @@ class SprykerNamespaceSniff implements \PHP_CodeSniffer_Sniff
 
         $filename = $phpcsFile->getFilename();
 
-        preg_match('#/(src|tests)/(Spryker|Unit)/(.*)#', $filename, $matches);
+        preg_match('#/(src|tests)/(Spryker|Unit/Spryker|Functional/Spryker)/(.*)#', $filename, $matches);
         if (!$matches) {
             return;
         }


### PR DESCRIPTION
100+ issues in core must be fixed before merging.

E.g.:

```
FILE: ...ness/Model/Elastisearch/Generator/IndexMapClassGeneratorTest.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 8 | ERROR | Namespace
   |       | `Unit\Spryker\Zed\Search\Business\Model\Generator` does
   |       | not fit to folder structure
   |       | `Unit\Spryker\Zed\Search\Business\Model\Elastisearch\Generator`
----------------------------------------------------------------------
```