### PR TITLE
Add psr-4 autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
   "support": {
     "source": "https://github.com/spryker/code-sniffer"
   },
+  "autoload": {
+    "psr-4": {
+      "Spryker\\": "Spryker"
+    }
+  },
   "require": {
     "php": ">=5.4.16",
     "squizlabs/php_codesniffer": "~2.5"


### PR DESCRIPTION
This adds autoloading which is required if projects want to reference sniffs in this repository. They extend an abstract class which needs to be required first - that's where the autoloading kicks in.