### PR TITLE
Api tag for PluginInterface type and allow throw tag for all api tagged methods

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -50,7 +50,11 @@ class DocBlockApiAnnotationSniff implements \PHP_CodeSniffer_Sniff
         $namespace = $this->getNamespace($phpCsFile, $stackPointer);
         $name = $this->getClassOrInterfaceName($phpCsFile, $stackPointer);
 
-        if ($this->isFacade($namespace, $name) || $this->isClient($namespace, $name) || $this->isQueryContainer($namespace, $name)) {
+        if ($this->isFacade($namespace, $name)
+            || $this->isClient($namespace, $name)
+            || $this->isQueryContainer($namespace, $name)
+            || $this->isPluginInterface($namespace, $name)
+        ) {
             return true;
         }
 
@@ -165,6 +169,21 @@ class DocBlockApiAnnotationSniff implements \PHP_CodeSniffer_Sniff
     protected function isClient($namespace, $name)
     {
         if (preg_match('/^Spryker\\\Client\\\[a-zA-Z]+$/', $namespace) && preg_match('/^(.*?)(Client|ClientInterface)/', $name)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function isPluginInterface($namespace, $name)
+    {
+        if (preg_match('/^Spryker\\\\[a-zA-Z]+\\\\[a-zA-Z]+\\\\Dependency\\\\Plugin\\\\/', $namespace) && preg_match('/^\w+Interface$/', $name)) {
             return true;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -183,7 +183,7 @@ class DocBlockApiAnnotationSniff implements \PHP_CodeSniffer_Sniff
      */
     protected function isPluginInterface($namespace, $name)
     {
-        if (preg_match('/^Spryker\\\\[a-zA-Z]+\\\\[a-zA-Z]+\\\\Dependency\\\\Plugin\\\\/', $namespace) && preg_match('/^\w+Interface$/', $name)) {
+        if (preg_match('/^Spryker\\\\[a-zA-Z]+\\\\[a-zA-Z]+\\\\Dependency\\\\Plugin\b/', $namespace) && preg_match('/^\w+Interface$/', $name)) {
             return true;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -52,6 +52,12 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
         $exceptions = $this->extractExceptions($phpCsFile, $stackPointer);
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
+
+        // We skip for Spryker @api containing methods
+        if ($this->isApiMethod($phpCsFile, $docBlockStartIndex)) {
+            return;
+        }
+
         $annotations = $this->extractExceptionAnnotations($phpCsFile, $docBlockStartIndex);
 
         $containsComplexThrowToken = $this->containsComplexThrowToken($tokens, $tokens[$stackPointer]['scope_opener'], $tokens[$stackPointer]['scope_closer']);
@@ -426,6 +432,25 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
             }
 
             return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpCsFile
+     * @param int $docBlockStartIndex
+     *
+     * @return bool
+     */
+    protected function isApiMethod(PHP_CodeSniffer_File $phpCsFile, $docBlockStartIndex)
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        foreach ($tokens[$docBlockStartIndex]['comment_tags'] as $index) {
+            if ($tokens[$index]['content'] === '@api') {
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
Requirement from Fabian:
- PluginInterface also now as API tag
- Throw tags allowed for all `@api` methods as part of contract definition
