### PR TITLE
Add Pyz check for core.

### DIFF
--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -22,7 +22,7 @@ class SprykerNamespaceSniff implements PHP_CodeSniffer_Sniff
      */
     public function register()
     {
-        return [T_CLASS];
+        return [T_CLASS, T_INTERFACE];
     }
 
     /**

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * (c) Spryker Systems GmbH copyright protected.
+ */
+
+namespace Spryker\Sniffs\Namespaces;
+
+use PHP_CodeSniffer_File;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+use Spryker\Traits\UseStatementsTrait;
+
+/**
+ * Makes sure the Pyz (project) namespace does not leak into the Spryker core one.
+ */
+class SprykerNoPyzSniff extends AbstractSprykerSniff
+{
+
+    use UseStatementsTrait;
+
+    const NAMESPACE_PROJECT = 'Pyz';
+
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        return [T_CLASS, T_INTERFACE, T_TRAIT];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if (!$this->isSprykerNamespace($phpcsFile)) {
+            return;
+        }
+
+        $useStatements = $this->getUseStatements($phpcsFile);
+        foreach ($useStatements as $useStatement) {
+            $namespace = $this->extractNamespace($useStatement['fullName']);
+            if ($namespace !== static::NAMESPACE_PROJECT) {
+                continue;
+            }
+
+            $phpcsFile->addError(sprintf('No %s namespace allowed in core files.', static::NAMESPACE_PROJECT), $useStatement['start'], 'InvalidPyzInSpryker');
+        }
+    }
+
+    /**
+     * @param string $fullClassName
+     *
+     * @return string
+     */
+    protected function extractNamespace($fullClassName) {
+        $namespaces = explode('\\', $fullClassName, 2);
+
+        return $namespaces[0];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpCsFile
+     *
+     * @return bool
+     */
+    protected function isSprykerNamespace(PHP_CodeSniffer_File $phpCsFile)
+    {
+        $namespace = $this->getNamespace($phpCsFile);
+
+        return ($namespace === static::NAMESPACE_SPRYKER);
+    }
+
+}

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -52,7 +52,8 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
      *
      * @return string
      */
-    protected function extractNamespace($fullClassName) {
+    protected function extractNamespace($fullClassName)
+    {
         $namespaces = explode('\\', $fullClassName, 2);
 
         return $namespaces[0];

--- a/Spryker/Sniffs/Namespaces/SprykerUseStatementSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerUseStatementSniff.php
@@ -22,16 +22,6 @@ class SprykerUseStatementSniff implements PHP_CodeSniffer_Sniff
     /**
      * @var array
      */
-    protected static $whiteListOfNamespaces = [
-        'Pyz',
-        'Orm',
-        'Generated',
-        'Spryker',
-    ];
-
-    /**
-     * @var array
-     */
     protected $existingStatements;
 
     /**
@@ -503,19 +493,6 @@ class SprykerUseStatementSniff implements PHP_CodeSniffer_Sniff
         }
 
         return false;
-    }
-
-    /**
-     * @param string $extractedUseStatement
-     *
-     * @return bool
-     */
-    protected function isValidNamespace($extractedUseStatement)
-    {
-        $firstSeparator = mb_strpos($extractedUseStatement, '\\');
-        $namespace = mb_substr($extractedUseStatement, 0, $firstSeparator);
-
-        return in_array($namespace, static::$whiteListOfNamespaces);
     }
 
     /**

--- a/Spryker/Sniffs/Namespaces/UseInAlphabeticalOrderSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseInAlphabeticalOrderSniff.php
@@ -75,7 +75,7 @@ class UseInAlphabeticalOrderSniff implements PHP_CodeSniffer_Sniff
             $next = $phpcsFile->findNext(T_USE, $next + 1);
         }
 
-     // Prevent multiple uses in the same file from entering
+        // Prevent multiple uses in the same file from entering
         $this->_processed[$phpcsFile->getFilename()] = true;
 
         foreach ($this->_uses as $scope => $used) {
@@ -130,7 +130,7 @@ class UseInAlphabeticalOrderSniff implements PHP_CodeSniffer_Sniff
      */
     protected function _checkUseToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-     // If the use token is for a closure we want to ignore it.
+        // If the use token is for a closure we want to ignore it.
         $isClosure = $this->_isClosure($phpcsFile, $stackPtr);
         if ($isClosure) {
             return;
@@ -146,8 +146,8 @@ class UseInAlphabeticalOrderSniff implements PHP_CodeSniffer_Sniff
             $content .= $tokens[$i]['content'];
         }
 
-     // Check for class scoping on use. Traits should be
-     // ordered independently.
+        // Check for class scoping on use. Traits should be
+        // ordered independently.
         $scope = 0;
         if (!empty($tokens[$i]['conditions'])) {
             $scope = key($tokens[$i]['conditions']);


### PR DESCRIPTION
Resolves https://github.com/spryker/code-sniffer/issues/32

Makes sure the Pyz (project) namespace does not leak into the Spryker core one.