### PR TITLE
DocBlockParamNotJustNullSniff

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -5,6 +5,7 @@ namespace Spryker\Sniffs\Commenting;
 use PHP_CodeSniffer_File;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 use Spryker\Tools\Traits\CommentingTrait;
+use Spryker\Tools\Traits\SignatureTrait;
 
 /**
  * Makes sure doc block param types allow `|null`, `|array` etc, when those are used
@@ -17,6 +18,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
 {
 
     use CommentingTrait;
+    use SignatureTrait;
 
     /**
      * @inheritDoc
@@ -119,66 +121,6 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
                 }
             }
         }
-    }
-
-    /**
-     * @param \PHP_CodeSniffer_File $phpCsFile
-     * @param int $stackPtr
-     *
-     * @return array
-     */
-    protected function getMethodSignature(PHP_CodeSniffer_File $phpCsFile, $stackPtr)
-    {
-        $tokens = $phpCsFile->getTokens();
-
-        $startIndex = $phpCsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1);
-        $endIndex = $tokens[$startIndex]['parenthesis_closer'];
-
-        $arguments = [];
-        $i = $startIndex;
-        while ($nextVariableIndex = $phpCsFile->findNext(T_VARIABLE, $i + 1, $endIndex)) {
-            $typehintIndex = $defaultIndex = $default = null;
-            $possibleTypeHint = $phpCsFile->findPrevious([T_ARRAY_HINT, T_CALLABLE], $nextVariableIndex - 1, $nextVariableIndex - 3);
-            if ($possibleTypeHint) {
-                $typehintIndex = $possibleTypeHint;
-            }
-
-            $possibleEqualIndex = $phpCsFile->findNext([T_EQUAL], $nextVariableIndex + 1, $nextVariableIndex + 3);
-            if ($possibleEqualIndex) {
-                $whitelist = [T_CONSTANT_ENCAPSED_STRING, T_TRUE, T_FALSE, T_NULL, T_OPEN_SHORT_ARRAY, T_LNUMBER, T_DNUMBER];
-                $possibleDefaultValue = $phpCsFile->findNext($whitelist, $possibleEqualIndex + 1, $possibleEqualIndex + 3);
-                if ($possibleDefaultValue) {
-                    $defaultIndex = $possibleDefaultValue;
-                    //$default = $tokens[$defaultIndex]['content'];
-                    if ($tokens[$defaultIndex]['code'] === T_CONSTANT_ENCAPSED_STRING) {
-                        $default = 'string';
-                    } elseif ($tokens[$defaultIndex]['code'] === T_OPEN_SHORT_ARRAY) {
-                        $default = 'array';
-                    } elseif ($tokens[$defaultIndex]['code'] === T_FALSE || $tokens[$defaultIndex]['code'] === T_TRUE) {
-                        $default = 'bool';
-                    } elseif ($tokens[$defaultIndex]['code'] === T_LNUMBER) {
-                        $default = 'int';
-                    } elseif ($tokens[$defaultIndex]['code'] === T_DNUMBER) {
-                        $default = 'float';
-                    } elseif ($tokens[$defaultIndex]['code'] === T_NULL) {
-                        $default = 'null';
-                    } else {
-                        //die('Invalid default type: ' . $default);
-                    }
-                }
-            }
-
-            $arguments[] = [
-                'variable' => $nextVariableIndex,
-                'typehintIndex' => $typehintIndex,
-                'defaultIndex' => $defaultIndex,
-                'default' => $default,
-            ];
-
-            $i = $nextVariableIndex;
-        }
-
-        return $arguments;
     }
 
 }

--- a/Spryker/Sniffs/Commenting/DocBlockParamNotJustNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamNotJustNullSniff.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Spryker\Sniffs\Commenting;
+
+use PHP_CodeSniffer_File;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+use Spryker\Tools\Traits\CommentingTrait;
+use Spryker\Tools\Traits\SignatureTrait;
+
+/**
+ * Makes sure doc block param types are never just `null`, but always another type and optionally nullable on top.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class DocBlockParamNotJustNullSniff extends AbstractSprykerSniff
+{
+
+    use CommentingTrait;
+    use SignatureTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(PHP_CodeSniffer_File $phpCsFile, $stackPointer)
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
+
+        if (!$docBlockEndIndex) {
+            return;
+        }
+
+        $methodSignature = $this->getMethodSignature($phpCsFile, $stackPointer);
+        if (!$methodSignature) {
+            return;
+        }
+
+        $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
+
+        $paramCount = 0;
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
+            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+                continue;
+            }
+            if (!in_array($tokens[$i]['content'], ['@param'])) {
+                continue;
+            }
+
+            if (empty($methodSignature[$paramCount])) {
+                continue;
+            }
+            $methodSignatureValue = $methodSignature[$paramCount];
+            $paramCount++;
+
+            $classNameIndex = $i + 2;
+
+            if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
+                // Let another sniffer take care of the missing type
+                continue;
+            }
+
+            $content = $tokens[$classNameIndex]['content'];
+
+            $appendix = '';
+            $spaceIndex = strpos($content, ' ');
+            if ($spaceIndex) {
+                $appendix = substr($content, $spaceIndex);
+                $content = substr($content, 0, $spaceIndex);
+            }
+            if (empty($content) || $content !== 'null') {
+                continue;
+            }
+
+            $phpCsFile->addError('"null" as only param type does not make sense', $classNameIndex, 'NotJustNull');
+        }
+    }
+
+}

--- a/Spryker/Sniffs/Commenting/DocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockSniff.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Spryker\Sniffs\Commenting;
+
+use PHP_CodeSniffer_File;
+use PHP_CodeSniffer_Tokens;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+use Spryker\Tools\Traits\CommentingTrait;
+use Spryker\Tools\Traits\SignatureTrait;
+
+/**
+ * Methods always need doc blocks.
+ * Constructor and destructor may not have one if they do not have arguments.
+ */
+class DocBlockSniff extends AbstractSprykerSniff
+{
+
+    use CommentingTrait;
+    use SignatureTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [T_FUNCTION];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextIndex = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        if ($tokens[$nextIndex]['content'] === '__construct' || $tokens[$nextIndex]['content'] === '__destruct') {
+            $this->checkConstructorAndDestructor($phpcsFile, $nextIndex);
+            return;
+        }
+
+        // Don't mess with closures
+        $prevIndex = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr - 1, null, true);
+        if (!$this->isGivenKind(PHP_CodeSniffer_Tokens::$methodPrefixes, $tokens[$prevIndex])) {
+            return;
+        }
+
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $stackPtr);
+        if ($docBlockEndIndex) {
+            return;
+        }
+
+        // We only look for void methods right now
+        $returnType = $this->detectReturnTypeVoid($phpcsFile, $stackPtr);
+        if ($returnType === null) {
+            $phpcsFile->addError('Method does not have a doc block: ' . $tokens[$nextIndex]['content'] . '()', $nextIndex);
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError('Method does not have a return void statement in doc block: ' . $tokens[$nextIndex]['content'], $nextIndex);
+        if (!$fix) {
+            return;
+        }
+
+        $this->addDocBlock($phpcsFile, $stackPtr, $returnType);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpcsFile
+     * @param int $index
+     * @param string $returnType
+     *
+     * @return void
+     */
+    protected function addDocBlock(PHP_CodeSniffer_File $phpcsFile, $index, $returnType)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $firstTokenOfLine = $this->getFirstTokenOfLine($tokens, $index);
+
+        $indentation = $this->getIndentationWhitespace($phpcsFile, $index);
+
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->addNewlineBefore($firstTokenOfLine);
+        $phpcsFile->fixer->addContentBefore($firstTokenOfLine, $indentation . ' */');
+        $phpcsFile->fixer->addNewlineBefore($firstTokenOfLine);
+        $phpcsFile->fixer->addContentBefore($firstTokenOfLine, $indentation . ' * @return ' . $returnType);
+        $phpcsFile->fixer->addNewlineBefore($firstTokenOfLine);
+        $phpcsFile->fixer->addContentBefore($firstTokenOfLine, $indentation . '/**');
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpcsFile
+     * @param int $index
+     *
+     * @return void
+     */
+    protected function checkConstructorAndDestructor(PHP_CodeSniffer_File $phpcsFile, $index)
+    {
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $index);
+        if ($docBlockEndIndex) {
+            return;
+        }
+
+        $methodSignature = $this->getMethodSignature($phpcsFile, $index);
+        $arguments = count($methodSignature);
+        if (!$arguments) {
+            return;
+        }
+
+        $phpcsFile->addError('Missing doc block for method', $index, 'ConstructDesctructMissingDocBlock');
+    }
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpcsFile
+     * @param int $docBlockStartIndex
+     * @param int $docBlockEndIndex
+     *
+     * @return int|null
+     */
+    protected function findDocBlockReturn(PHP_CodeSniffer_File $phpcsFile, $docBlockStartIndex, $docBlockEndIndex)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
+            if (!$this->isGivenKind(T_DOC_COMMENT_TAG, $tokens[$i])) {
+                continue;
+            }
+            if ($tokens[$i]['content'] !== '@return') {
+                continue;
+            }
+
+            return $i;
+        }
+
+        return null;
+    }
+
+    /**
+     * For right now we only try to detect void.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile
+     * @param int $index
+     *
+     * @return string|null
+     */
+    protected function detectReturnTypeVoid(PHP_CodeSniffer_File $phpcsFile, $index)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $type = 'void';
+
+        if (empty($tokens[$index]['scope_opener'])) {
+            return null;
+        }
+
+        $methodStartIndex = $tokens[$index]['scope_opener'];
+        $methodEndIndex = $tokens[$index]['scope_closer'];
+
+        for ($i = $methodStartIndex + 1; $i < $methodEndIndex; ++$i) {
+            if ($this->isGivenKind([T_FUNCTION], $tokens[$i])) {
+                $endIndex = $tokens[$i]['scope_closer'];
+                $i = $endIndex;
+                continue;
+            }
+
+            if (!$this->isGivenKind([T_RETURN], $tokens[$i])) {
+                continue;
+            }
+
+            $nextIndex = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $i + 1, null, true);
+            if (!$this->isGivenKind(T_SEMICOLON, $tokens[$nextIndex])) {
+                return null;
+            }
+        }
+
+        return $type;
+    }
+
+}

--- a/Spryker/Tools/Traits/SignatureTrait.php
+++ b/Spryker/Tools/Traits/SignatureTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Spryker\Tools\Traits;
+
+use PHP_CodeSniffer_File;
+
+/**
+ * Method signature functionality.
+ */
+trait SignatureTrait
+{
+
+    /**
+     * @param \PHP_CodeSniffer_File $phpCsFile
+     * @param int $stackPtr
+     *
+     * @return array
+     */
+    protected function getMethodSignature(PHP_CodeSniffer_File $phpCsFile, $stackPtr)
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        $startIndex = $phpCsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1);
+        $endIndex = $tokens[$startIndex]['parenthesis_closer'];
+
+        $arguments = [];
+        $i = $startIndex;
+        while ($nextVariableIndex = $phpCsFile->findNext(T_VARIABLE, $i + 1, $endIndex)) {
+            $typehintIndex = $defaultIndex = $default = null;
+            $possibleTypeHint = $phpCsFile->findPrevious([T_ARRAY_HINT, T_CALLABLE], $nextVariableIndex - 1, $nextVariableIndex - 3);
+            if ($possibleTypeHint) {
+                $typehintIndex = $possibleTypeHint;
+            }
+
+            $possibleEqualIndex = $phpCsFile->findNext([T_EQUAL], $nextVariableIndex + 1, $nextVariableIndex + 3);
+            if ($possibleEqualIndex) {
+                $whitelist = [T_CONSTANT_ENCAPSED_STRING, T_TRUE, T_FALSE, T_NULL, T_OPEN_SHORT_ARRAY, T_LNUMBER, T_DNUMBER];
+                $possibleDefaultValue = $phpCsFile->findNext($whitelist, $possibleEqualIndex + 1, $possibleEqualIndex + 3);
+                if ($possibleDefaultValue) {
+                    $defaultIndex = $possibleDefaultValue;
+                    //$default = $tokens[$defaultIndex]['content'];
+                    if ($tokens[$defaultIndex]['code'] === T_CONSTANT_ENCAPSED_STRING) {
+                        $default = 'string';
+                    } elseif ($tokens[$defaultIndex]['code'] === T_OPEN_SHORT_ARRAY) {
+                        $default = 'array';
+                    } elseif ($tokens[$defaultIndex]['code'] === T_FALSE || $tokens[$defaultIndex]['code'] === T_TRUE) {
+                        $default = 'bool';
+                    } elseif ($tokens[$defaultIndex]['code'] === T_LNUMBER) {
+                        $default = 'int';
+                    } elseif ($tokens[$defaultIndex]['code'] === T_DNUMBER) {
+                        $default = 'float';
+                    } elseif ($tokens[$defaultIndex]['code'] === T_NULL) {
+                        $default = 'null';
+                    } else {
+                        //die('Invalid default type: ' . $default);
+                    }
+                }
+            }
+
+            $arguments[] = [
+                'variable' => $nextVariableIndex,
+                'typehintIndex' => $typehintIndex,
+                'defaultIndex' => $defaultIndex,
+                'default' => $default,
+            ];
+
+            $i = $nextVariableIndex;
+        }
+
+        return $arguments;
+    }
+
+}


### PR DESCRIPTION
- Makes sure doc block param types are never just `null`

Also:
- Makes sure doc blocks are always present where necessary.