### PR TITLE
Fix `UseInAlphabeticalOrderSniff` sorting order — issue #74

### DIFF
--- a/Spryker/Sniffs/Namespaces/UseInAlphabeticalOrderSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseInAlphabeticalOrderSniff.php
@@ -79,10 +79,9 @@ class UseInAlphabeticalOrderSniff implements PHP_CodeSniffer_Sniff
         $this->_processed[$phpcsFile->getFilename()] = true;
 
         foreach ($this->_uses as $scope => $used) {
-            $defined = $sorted = array_keys($used);
+            $defined = array_keys($used);
 
-            natcasesort($sorted);
-            $sorted = array_values($sorted);
+            $sorted = $this->sortImportsAlphabetically($defined);
             if ($sorted === $defined) {
                 continue;
             }
@@ -173,6 +172,40 @@ class UseInAlphabeticalOrderSniff implements PHP_CodeSniffer_Sniff
             null,
             true
         );
+    }
+
+    /**
+     * @param array $imports
+     *
+     * @return array
+     */
+    protected function sortImportsAlphabetically(array $imports)
+    {
+        $hashSlashes = true;
+        $hashed = $this->replaceSeparators($imports, $hashSlashes);
+        natcasesort($hashed);
+        $sorted = $this->replaceSeparators($hashed, !$hashSlashes);
+
+        return array_values($sorted);
+    }
+
+    /**
+     * @param array $imports
+     * @param bool $hashSlashes
+     *
+     * @return array
+     */
+    protected function replaceSeparators(array $imports, $hashSlashes = false)
+    {
+        $search = $hashSlashes ? '\\' : '##';
+        $replace = $hashSlashes ? '##' : '\\';
+
+        $sorted = [];
+        foreach ($imports as $import) {
+            $sorted[] = str_replace($search, $replace, $import);
+        };
+
+        return $sorted;
     }
 
 }

--- a/Spryker/tests/files/Namespaces/UseInAlphabeticalOrderPass.php
+++ b/Spryker/tests/files/Namespaces/UseInAlphabeticalOrderPass.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Bundle\Business\Foo;
+
+use Spryker\Zed\Bundle\Business\Foo\Bar\Baz\Foo;
+use Spryker\Zed\Bundle\Business\Foo\BarBaz;
+use Spryker\Zed\Bundle\Business\FooBar\Bar;
+use Spryker\Zed\Bundle\Business\FooBarBaz;
+
+class UseInAlphabeticalOrderPass
+{
+
+    /**
+     * @return bool
+     */
+    public function method()
+    {
+        $foo = new Foo();
+        $bar = new Bar();
+        $barbaz = new BarBaz();
+        $foobarbaz = new FooBarBaz();
+
+        return isset($foo, $bar, $barbaz, $foobarbaz);
+    }
+
+}


### PR DESCRIPTION
`spryker/code-sniffer` was reporting that the following is in the wrong order (which is the way `PhpStorm` is sorting):
```
use Spryker\Zed\Bundle\Business\Foo\Bar\Baz\Foo;
use Spryker\Zed\Bundle\Business\Foo\BarBaz;
use Spryker\Zed\Bundle\Business\FooBar\Bar;
use Spryker\Zed\Bundle\Business\FooBarBaz;
```
`spryker/code-sniffer` was fixing to (and considered to be the _correct_ way of sorting):
```
use Spryker\Zed\Bundle\Business\FooBarBaz;
use Spryker\Zed\Bundle\Business\FooBar\Bar;
use Spryker\Zed\Bundle\Business\Foo\BarBaz;
use Spryker\Zed\Bundle\Business\Foo\Bar\Baz\Foo;
```
This `PR` makes ordering of imports _compatible_ with `PhpStorm`.
