### PR TITLE
Exclude PhpStorm internal stuff (located at `.idea/*`) from sniffing

### DIFF
--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -6,6 +6,7 @@
         All sniffs in ./Sniffs will be auto loaded
     </description>
 
+    <exclude-pattern>\.idea</exclude-pattern>
     <exclude-pattern>\.git</exclude-pattern>
     <exclude-pattern>*/src/Generated/*</exclude-pattern>
     <exclude-pattern>*/src/Orm/*</exclude-pattern>


### PR DESCRIPTION
Whenever project uses `file templates` for `PHP` classes, they are saved in `/project/.idea/fileTemplates/internal/` but `sniffer` finds them and complains:
```
FILE: /project/.idea/fileTemplates/internal/PHP Class.php
----------------------------------------------------------------------
FOUND 6 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
  7 | ERROR | [x] There must be one blank line after the namespace
    |       |     declaration
  7 | ERROR | [x] There must be one blank line after the namespace
    |       |     declaration
 10 | ERROR | [ ] Class name doesn't match filename; expected "class
    |       |     PHP Class"
 10 | ERROR | [x] Opening brace of a class must be on the line after
    |       |     the definition
 10 | ERROR | [x] Opening brace of a class must have one extra new
    |       |     line between itself and the first content.
 10 | ERROR | [x] Closing brace of a class must have one extra new
    |       |     line between itself and the last content.
----------------------------------------------------------------------
PHPCBF CAN FIX THE 5 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```