### PR TITLE
Adjust <exclude-pattern> rules

### DIFF
--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -14,7 +14,6 @@
     <exclude-pattern>*/tests/_helpers/*</exclude-pattern>
     <exclude-pattern>*/tests/_output/*</exclude-pattern>
     <exclude-pattern>*/Fixtures/*</exclude-pattern>
-    <exclude-pattern>*/Propel/*</exclude-pattern>
     <exclude-pattern>*/data/*</exclude-pattern>
     <exclude-pattern>*.xml</exclude-pattern>
     <exclude-pattern>*.css</exclude-pattern>

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -14,8 +14,8 @@
     <exclude-pattern>*/tests/_helpers/*</exclude-pattern>
     <exclude-pattern>*/tests/_output/*</exclude-pattern>
     <exclude-pattern>*/Fixtures/*</exclude-pattern>
-    <exclude-pattern>*/Propel/DE/Migration/*</exclude-pattern>
-    <exclude-pattern>*/data/DE/cache/*</exclude-pattern>
+    <exclude-pattern>*/Propel/*</exclude-pattern>
+    <exclude-pattern>*/data/*</exclude-pattern>
     <exclude-pattern>*.xml</exclude-pattern>
     <exclude-pattern>*.css</exclude-pattern>
     <exclude-pattern>*.js</exclude-pattern>

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -14,7 +14,8 @@
     <exclude-pattern>*/tests/_helpers/*</exclude-pattern>
     <exclude-pattern>*/tests/_output/*</exclude-pattern>
     <exclude-pattern>*/Fixtures/*</exclude-pattern>
-    <exclude-pattern>*/data/*</exclude-pattern>
+    <exclude-pattern>*/data/*/development/*</exclude-pattern>
+    <exclude-pattern>*/data/*/logs/*</exclude-pattern>
     <exclude-pattern>*.xml</exclude-pattern>
     <exclude-pattern>*.css</exclude-pattern>
     <exclude-pattern>*.js</exclude-pattern>

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -14,8 +14,7 @@
     <exclude-pattern>*/tests/_helpers/*</exclude-pattern>
     <exclude-pattern>*/tests/_output/*</exclude-pattern>
     <exclude-pattern>*/Fixtures/*</exclude-pattern>
-    <exclude-pattern>*/data/*/development/*</exclude-pattern>
-    <exclude-pattern>*/data/*/logs/*</exclude-pattern>
+    <exclude-pattern>*/data/*/</exclude-pattern>
     <exclude-pattern>*.xml</exclude-pattern>
     <exclude-pattern>*.css</exclude-pattern>
     <exclude-pattern>*.js</exclude-pattern>

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -14,7 +14,7 @@
     <exclude-pattern>*/tests/_helpers/*</exclude-pattern>
     <exclude-pattern>*/tests/_output/*</exclude-pattern>
     <exclude-pattern>*/Fixtures/*</exclude-pattern>
-    <exclude-pattern>*/data/*/</exclude-pattern>
+    <exclude-pattern>*/data/*</exclude-pattern>
     <exclude-pattern>*.xml</exclude-pattern>
     <exclude-pattern>*.css</exclude-pattern>
     <exclude-pattern>*.js</exclude-pattern>


### PR DESCRIPTION
Not all shops can have `store` named `"DE"`, therefore `code-sniffer` checks unrelated directories for other `stores` (and fails when diving into `data/MY-STORE/cache/Yves/twig/*`).

Changing `*/data/DE/cache/*` to `*/data/*`, and `*/Propel/DE/Migration/*` to `*/Propel/*` fixes this problem.