### PR TITLE
Allow PyzTest file doc blocks to be fixed

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -35,7 +35,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     {
         $filename = $phpCsFile->getFilename();
 
-        preg_match('#/(tests)/(SprykerTest)/(.+)(Test|Cest).php$#', $filename, $matches);
+        preg_match('#/(tests)/(SprykerTest|PyzTest)/(.+)(Test|Cest).php$#', $filename, $matches);
         if (!$matches) {
             return;
         }


### PR DESCRIPTION
PyzTest file doc blocks are now also automatically fixed.