### PR TITLE
Reverse alias generation

### DIFF
--- a/Spryker/Sniffs/Namespaces/UseStatementSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseStatementSniff.php
@@ -579,8 +579,6 @@ class UseStatementSniff implements Sniff
         $alias = $shortName;
         $count = 0;
         $pieces = explode('\\', $fullName);
-        $pieces = array_reverse($pieces);
-        array_shift($pieces);
 
         // To avoid collisions with PHP core classes we try to add this prefix for all root namespaced classes
         if (count($pieces) < 1) {


### PR DESCRIPTION
Previously an FQCN was resolved by creating an alias which is generated from the original class name from right to left. This is now changed to be generated from left to right.

Old:
Foo\Bar\Baz\ClassName -> as BazClassName

New:
Foo\Bar\Baz\ClassName -> as FooClassName