### PR TITLE
Fix a missing error code, make errors more descriptive

### DIFF
--- a/Spryker/Sniffs/Commenting/SprykerFacadeSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerFacadeSniff.php
@@ -60,7 +60,7 @@ class SprykerFacadeSniff implements Sniff
     }
 
     /**
-     * Facade interfaces must have a "Specification" block as part of the contract.
+     * Facade methods need to appear in its interface (and vice versa)
      *
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
@@ -81,12 +81,26 @@ class SprykerFacadeSniff implements Sniff
         $interfaceMethods = $matches[1];
         asort($interfaceMethods);
 
-        if (array_values($interfaceMethods) !== array_values($methods)) {
-            $missingMethods = array_diff($methods, $interfaceMethods);
+        if (array_values($interfaceMethods) === array_values($methods)) {
+            return;
+        }
 
+        $missingInterfaceMethods = array_diff($methods, $interfaceMethods);
+        $missingInterfaceImplementations = array_diff($interfaceMethods, $methods);
+
+        if (count($missingInterfaceMethods) > 0) {
             $phpCsFile->addError(
-                sprintf('Interface methods do not match facade methods: "%s" missing', implode(', ', $missingMethods), 'InterfaceMethodsNotMatch'),
-                $stackPointer
+                sprintf('Interface methods do not match facade methods: "%s" missing', implode(', ', $missingInterfaceMethods), 'InterfaceMethodsNotMatch'),
+                $stackPointer,
+                'InterfaceMethodMissing'
+            );
+        }
+
+        if (count($missingInterfaceImplementations) > 0) {
+            $phpCsFile->addError(
+                sprintf('Interface method has no implementation: "%s" missing', implode(', ', $missingInterfaceImplementations), 'InterfaceMethodsNotMatch'),
+                $stackPointer,
+                'InterfaceImplementationMissing'
             );
         }
     }


### PR DESCRIPTION
An unimplemented method in a facade led to a fatal error when running the sniffer.
While at it, I improved the error a bit (an unimplemented method resulted in a strange error message before)
The documentation was also lying.