### PR TITLE
Fix inline condition (ternary) spacing.

### DIFF
--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -54,8 +54,14 @@
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
 
     <rule ref="PEAR.ControlStructures.ControlSignature"/>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
+
+    <rule ref="Squiz.ControlStructures.InlineIfDeclaration"/>
+    <rule ref="Squiz.ControlStructures.InlineIfDeclaration.NoBrackets">
+        <severity>0</severity>
+    </rule>
 
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <severity>0</severity>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The Spryker standard contains 139 sniffs
+The Spryker standard contains 140 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -134,7 +134,7 @@ Spryker (63 sniffs)
 - Spryker.WhiteSpace.ObjectAttributeSpacing
 - Spryker.WhiteSpace.OperatorSpacing
 
-Squiz (25 sniffs)
+Squiz (26 sniffs)
 -----------------
 - Squiz.Arrays.ArrayBracketSpacing
 - Squiz.Classes.LowercaseClassKeywords
@@ -143,6 +143,7 @@ Squiz (25 sniffs)
 - Squiz.ControlStructures.ControlSignature
 - Squiz.ControlStructures.ForEachLoopDeclaration
 - Squiz.ControlStructures.ForLoopDeclaration
+- Squiz.ControlStructures.InlineIfDeclaration
 - Squiz.ControlStructures.LowercaseDeclaration
 - Squiz.Functions.FunctionDeclaration
 - Squiz.Functions.FunctionDeclarationArgumentSpacing


### PR DESCRIPTION
Resolves https://github.com/spryker/code-sniffer/issues/126

Requires RFC pass for new rule:
- inline ternary must be single line, otherwise use normal if() clause for clarity.

https://github.com/spryker/spryker/pull/3650/files#diff-8ef68e510ce64aca66c3d1e6d162dcceR133

```php
        $constraints = empty($builder->getOption(static::OPTION_SUPER_ATTRIBUTES)) ?
            [] :
            [
                new ProductAttributesNotBlank(),
                new ProductAttributeUniqueCombination(
                    $this->getFactory()->getProductFacade(),
                    (int)$options[static::OPTION_ID_PRODUCT_ABSTRACT]
                ),
            ];


```