### PR TITLE
Make sure falsey values are the end of the param/return list.

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -135,19 +135,17 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     {
         global $sortOrder;
 
-        $ai = array_search($a, $sortOrder);
-        $bi = array_search($b, $sortOrder);
-        if ($ai === false && $bi === false) {
-            return -1;
-        }
-        if ($ai !== false && $bi === false) {
-            return 1;
-        }
-        if ($bi !== false && $ai === false) {
+        $aIndex = array_search($a, $sortOrder);
+        $bIndex = array_search($b, $sortOrder);
+        if ($aIndex === false) {
             return -1;
         }
 
-        return $ai - $bi;
+        if ($bIndex === false) {
+            return 1;
+        }
+
+        return $aIndex - $bIndex;
     }
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -13,7 +13,7 @@ use Spryker\Tools\Traits\CommentingTrait;
 use Spryker\Tools\Traits\SignatureTrait;
 
 /**
- * Makes sure doc block param/return types have the right order and don't duplicate.
+ * Makes sure doc block param/return types have the right order and do not duplicate.
  *
  * @author Mark Scherer
  * @license MIT
@@ -49,14 +49,12 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
      */
     public function process(File $phpCsFile, $stackPointer)
     {
-        $tokens = $phpCsFile->getTokens();
-
         $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
-
         if (!$docBlockEndIndex) {
             return;
         }
 
+        $tokens = $phpCsFile->getTokens();
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
         if ($this->hasInheritDoc($phpCsFile, $docBlockStartIndex, $docBlockEndIndex)) {

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+use Spryker\Tools\Traits\CommentingTrait;
+use Spryker\Tools\Traits\SignatureTrait;
+
+/**
+ * Makes sure doc block param/return types have the right order and don't duplicate.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class DocBlockTypeOrderSniff extends AbstractSprykerSniff
+{
+    use CommentingTrait;
+    use SignatureTrait;
+
+    /**
+     * Highest/First element will be last in list of param or return tag.
+     *
+     * @var array
+     */
+    protected $sortMap = [
+        'void',
+        'null',
+        'false',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpCsFile, $stackPointer)
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
+
+        if (!$docBlockEndIndex) {
+            return;
+        }
+
+        $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
+
+        if ($this->hasInheritDoc($phpCsFile, $docBlockStartIndex, $docBlockEndIndex)) {
+            return;
+        }
+
+        $docBlockParams = [];
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
+            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+                continue;
+            }
+            if (!in_array($tokens[$i]['content'], ['@param', '@return'])) {
+                continue;
+            }
+
+            $classNameIndex = $i + 2;
+
+            if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
+                continue;
+            }
+
+            $content = $tokens[$classNameIndex]['content'];
+
+            $appendix = '';
+            $spacePos = strpos($content, ' ');
+            if ($spacePos) {
+                $appendix = substr($content, $spacePos);
+                $content = substr($content, 0, $spacePos);
+            }
+
+            preg_match('/\$[^\s]+/', $appendix, $matches);
+            $variable = $matches ? $matches[0] : '';
+
+            $docBlockParams[] = [
+                'index' => $classNameIndex,
+                'type' => $content,
+                'variable' => $variable,
+                'appendix' => $appendix,
+            ];
+        }
+
+        $this->assertOrder($phpCsFile, $docBlockParams);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param array $docBlockParams
+     *
+     * @return void
+     */
+    protected function assertOrder(File $phpCsFile, array $docBlockParams): void
+    {
+        foreach ($docBlockParams as $docBlockParam) {
+            if (strpos($docBlockParam['type'], '$') !== false) {
+                continue;
+            }
+
+            $pieces = explode('|', $docBlockParam['type']);
+            if (count($pieces) === 1) {
+                continue;
+            }
+
+            $unique = array_unique($pieces);
+            if (count($pieces) !== count($unique)) {
+                $phpCsFile->addError('Duplicate type in `' . $docBlockParam['type'] . '`', $docBlockParam['index'], 'Duplicate');
+                continue;
+            }
+            $expectedOrder = $this->getExpectedOrder($pieces);
+            if ($expectedOrder === $pieces) {
+                continue;
+            }
+
+            $fix = $phpCsFile->addFixableError('`null` and falsey values should be the last element', $docBlockParam['index'], 'WrongOrder');
+            if (!$fix) {
+                continue;
+            }
+
+            $phpCsFile->fixer->beginChangeset();
+
+            $content = implode('|', $expectedOrder) . $docBlockParam['appendix'];
+            $phpCsFile->fixer->replaceToken($docBlockParam['index'], $content);
+
+            $phpCsFile->fixer->endChangeset();
+        }
+    }
+
+    /**
+     * @param array $pieces
+     *
+     * @return array
+     */
+    protected function getExpectedOrder(array $pieces): array
+    {
+        global $sortOrder;
+
+        $sortOrder = array_reverse($this->sortMap);
+        usort($pieces, [$this, "compare"]);
+
+        return $pieces;
+    }
+
+    /**
+     * @param string $a
+     * @param string $b
+     *
+     * @return int
+     */
+    protected function compare(string $a, string $b): int
+    {
+        global $sortOrder;
+
+        $ai = array_search($a, $sortOrder);
+        $bi = array_search($b, $sortOrder);
+        if ($ai === false && $bi === false) {
+            return -1;
+        }
+        if ($ai !== false && $bi === false) {
+            return 1;
+        }
+        if ($bi !== false && $ai === false) {
+            return -1;
+        }
+        if ($ai !== false && $bi !== false) {
+            return $ai - $bi;
+        }
+
+        return $a < $b ? -1 : 1;
+    }
+}

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -146,7 +146,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
     /**
      * @param array $token
      *
-     * @return null|string
+     * @return string|null
      */
     protected function detectType(array $token): ?string
     {

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -164,7 +164,7 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      *
-     * @return null|string
+     * @return string|null
      */
     protected function findCustomLicense(File $phpCsFile): ?string
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The Spryker standard contains 140 sniffs
+The Spryker standard contains 141 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -69,7 +69,7 @@ SlevomatCodingStandard (10 sniffs)
 - SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 
-Spryker (63 sniffs)
+Spryker (64 sniffs)
 -------------------
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
@@ -91,6 +91,7 @@ Spryker (63 sniffs)
 - Spryker.Commenting.DocBlockTestGroupAnnotation
 - Spryker.Commenting.DocBlockTestGroupAnnotation2
 - Spryker.Commenting.DocBlockThrows
+- Spryker.Commenting.DocBlockTypeOrder
 - Spryker.Commenting.DocBlockVar
 - Spryker.Commenting.DocBlockVarNotJustNull
 - Spryker.Commenting.FileDocBlock


### PR DESCRIPTION
Always annotate the primary intention, that means the actual value first, then the alternative ones.

Requires core changes first.
Waiting for this + "adjustment time of x days".