### PR TITLE
Add const visibility sniff without autofixing.

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -15,10 +15,10 @@ abstract class AbstractSprykerSniff implements Sniff
 {
     use BasicsTrait;
 
-    const NAMESPACE_SPRYKER = 'Spryker';
-    const NAMESPACE_SPRYKER_SHOP = 'SprykerShop';
-    const NAMESPACE_SPRYKER_SDK = 'SprykerSdk';
-    const NAMESPACE_SPRYKER_ECO = 'SprykerEco';
+    protected const NAMESPACE_SPRYKER = 'Spryker';
+    protected const NAMESPACE_SPRYKER_SHOP = 'SprykerShop';
+    protected const NAMESPACE_SPRYKER_SDK = 'SprykerSdk';
+    protected const NAMESPACE_SPRYKER_ECO = 'SprykerEco';
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile

--- a/Spryker/Sniffs/Commenting/AbstractFileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/AbstractFileDocBlockSniff.php
@@ -12,11 +12,11 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
 {
-    const EXPECTED_COMMENT_FIRST_LINE_STRING = 'Copyright © %s-present Spryker Systems GmbH. All rights reserved.';
-    const EXPECTED_COMMENT_SECOND_LINE_STRING = 'Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.';
+    protected const EXPECTED_COMMENT_FIRST_LINE_STRING = 'Copyright © %s-present Spryker Systems GmbH. All rights reserved.';
+    protected const EXPECTED_COMMENT_SECOND_LINE_STRING = 'Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.';
 
-    const SPRYKER_NAMESPACE = 'Spryker';
-    const YEAR = '2016';
+    protected const SPRYKER_NAMESPACE = 'Spryker';
+    protected const YEAR = '2016';
 
     /**
      * @var array

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -16,8 +16,8 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
 {
-    const ANNOTATION_START_TEXT = 'Auto-generated group annotations';
-    const ANNOTATION_END_TEXT = 'Add your own group annotations below this line';
+    protected const ANNOTATION_START_TEXT = 'Auto-generated group annotations';
+    protected const ANNOTATION_END_TEXT = 'Add your own group annotations below this line';
 
     /**
      * @return array

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -14,9 +14,9 @@ use PHP_CodeSniffer\Files\File;
  */
 class FileDocBlockSniff extends AbstractFileDocBlockSniff
 {
-    const FIRST_COMMENT_LINE_POSITION = 5;
-    const SECOND_COMMENT_LINE_POSITION = 10;
-    const EXPECTED_FILE_DOC_BLOCK_TOKEN_COUNT = 14;
+    protected const FIRST_COMMENT_LINE_POSITION = 5;
+    protected const SECOND_COMMENT_LINE_POSITION = 10;
+    protected const EXPECTED_FILE_DOC_BLOCK_TOKEN_COUNT = 14;
 
     /**
      * This property can be filled within the ruleset configuration file

--- a/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
@@ -14,7 +14,7 @@ use PHP_CodeSniffer\Files\File;
  */
 class SprykerConstantsSniff extends AbstractFileDocBlockSniff
 {
-    const EXPLANATION_CONSTANTS_INTERFACE = 'Declares global environment configuration keys. Do not use it for other class constants.';
+    protected const EXPLANATION_CONSTANTS_INTERFACE = 'Declares global environment configuration keys. Do not use it for other class constants.';
 
     /**
      * We must support class for now, as well - for BC.

--- a/Spryker/Sniffs/Factory/QueryContainerMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/Factory/QueryContainerMethodAnnotationSniff.php
@@ -14,7 +14,7 @@ use PHP_CodeSniffer\Files\File;
  */
 class QueryContainerMethodAnnotationSniff extends AbstractFactoryMethodAnnotationSniff
 {
-    const LAYER_PERSISTENCE = 'Persistence';
+    protected const LAYER_PERSISTENCE = 'Persistence';
 
     /**
      * @inheritdoc

--- a/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Do not use namespaced function usage.
+ */
+class FunctionNamespaceSniff implements Sniff
+{
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        return [T_STRING];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenContent = $tokens[$stackPtr]['content'];
+
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
+            return;
+        }
+
+        $separatorIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if (!$separatorIndex || $tokens[$separatorIndex]['type'] !== 'T_NS_SEPARATOR') {
+            return;
+        }
+
+        // We skip for non trivial cases
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($separatorIndex - 1), null, true);
+        if (!$previous || $tokens[$previous]['type'] === 'T_STRING') {
+            return;
+        }
+
+        $error = 'Function name ' . $tokenContent . '() found, should not be \ prefixed.';
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NamespaceInvalid');
+        if ($fix) {
+            $phpcsFile->fixer->replaceToken($separatorIndex, '');
+        }
+    }
+}

--- a/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
@@ -18,10 +18,10 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
 {
     use UseStatementsTrait;
 
-    const NAMESPACE_YVES = 'Yves';
-    const NAMESPACE_ZED = 'Zed';
+    protected const NAMESPACE_YVES = 'Yves';
+    protected const NAMESPACE_ZED = 'Zed';
 
-    const INVALID_PAIRS = [
+    protected const INVALID_PAIRS = [
         [
             'from' => self::NAMESPACE_YVES,
             'to' => self::NAMESPACE_ZED,

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -18,7 +18,7 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
 {
     use UseStatementsTrait;
 
-    const NAMESPACE_PROJECT = 'Pyz';
+    protected const NAMESPACE_PROJECT = 'Pyz';
 
     /**
      * @inheritdoc

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class PhpSapiConstantSniff implements Sniff
 {
-    const PHP_SAPI = 'PHP_SAPI';
+    protected const PHP_SAPI = 'PHP_SAPI';
 
     /**
      * @inheritdoc

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -39,7 +39,10 @@
     </rule>
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
 
+    <!-- Disabled for now
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+    -->
+
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
 

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -35,6 +35,10 @@
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
 
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
+
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
 

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -32,7 +32,11 @@
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
-    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
+        <properties>
+            <property name="fixable" type="bool" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
 
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -32,6 +32,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
 
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "slevomat/coding-standard": "^4.8.1",
+    "slevomat/coding-standard": "^4.8.3",
     "squizlabs/php_codesniffer": "^3.0"
   },
   "require-dev": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The Spryker standard contains 151 sniffs
+The Spryker standard contains 154 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -56,12 +56,14 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (18 sniffs)
+SlevomatCodingStandard (21 sniffs)
 ----------------------------------
+- SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment
 - SlevomatCodingStandard.Commenting.EmptyComment
+- SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch
 - SlevomatCodingStandard.ControlStructures.DisallowYodaComparison
 - SlevomatCodingStandard.ControlStructures.NewWithParentheses
 - SlevomatCodingStandard.Exceptions.DeadCatch
@@ -76,6 +78,7 @@ SlevomatCodingStandard (18 sniffs)
 - SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
 - SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
+- SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
 Spryker (66 sniffs)
 -------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The Spryker standard contains 150 sniffs
+The Spryker standard contains 151 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -56,9 +56,10 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (17 sniffs)
+SlevomatCodingStandard (18 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
+- SlevomatCodingStandard.Classes.ClassConstantVisibility
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment
 - SlevomatCodingStandard.Commenting.EmptyComment
 - SlevomatCodingStandard.ControlStructures.DisallowYodaComparison

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The Spryker standard contains 154 sniffs
+The Spryker standard contains 155 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -80,7 +80,7 @@ SlevomatCodingStandard (21 sniffs)
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Spryker (66 sniffs)
+Spryker (67 sniffs)
 -------------------
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
@@ -131,6 +131,7 @@ Spryker (66 sniffs)
 - Spryker.Namespaces.SprykerNoPyz
 - Spryker.Namespaces.UseStatement
 - Spryker.Namespaces.UseWithAliasing
+- Spryker.PHP.FunctionNamespace
 - Spryker.PHP.NoIsNull
 - Spryker.PHP.PhpSapiConstant
 - Spryker.PHP.PreferCastOverFunction

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The Spryker standard contains 155 sniffs
+The Spryker standard contains 154 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -56,9 +56,8 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (21 sniffs)
+SlevomatCodingStandard (20 sniffs)
 ----------------------------------
-- SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment


### PR DESCRIPTION
Last preparation for 0.13.0 release

We dont autofix as a developer must think about the use case of constants in each class.

People can activate the autofixing for their branch/module via
```xml
    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
        <properties>
            <property name="fixable" type="bool" value="true"/>
        </properties>
    </rule>
```