### PR TITLE
Fixed PHPStan version and added autoload for token constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "squizlabs/php_codesniffer": "^3.0"
   },
   "require-dev": {
-    "phpstan/phpstan-shim": "^0.9.2",
+    "phpstan/phpstan-shim": "^0.10.0",
     "phpunit/phpunit": "<5.0"
   },
   "scripts": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,3 +6,5 @@ $manualAutoload = dirname(__DIR__) . '/vendor/squizlabs/php_codesniffer/autoload
 if (!class_exists(\PHP_CodeSniffer\Config::class) && file_exists($manualAutoload)) {
     require $manualAutoload;
 }
+
+\PHP_CodeSniffer\Autoload::load('PHP_CodeSniffer\Util\Tokens');


### PR DESCRIPTION
#### Overview
* Added autoload for Token's constants being loaded before start of analyzing
* Update phpstan version since previous caused an error `Sniffs/Commenting/SprykerConstantsSniff.php:207
Method Spryker\Sniffs\Commenting\SprykerConstantsSniff::findDocBlock() should return int|null but returns bool|int.`. Method (\PHP_CodeSniffer\Files\File::findPrevious) issue: DocBlock shows `@return int|null` but the body has `return true`.