### PR TITLE
DT-795 Chainable fixes.

### DIFF
--- a/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+
+/**
+ * In method return types self for chaining methods is disallowed as it is poorly supported by the language.
+ *
+ * @author Mark Scherer
+ */
+class ReturnTypeHintSniff extends AbstractSprykerSniff
+{
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        return [T_FUNCTION];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $openParenthesisIndex = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1);
+        $closeParenthesisIndex = $tokens[$openParenthesisIndex]['parenthesis_closer'];
+
+        $colonIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $closeParenthesisIndex + 1, null, true);
+        if (!$colonIndex) {
+            return;
+        }
+
+        $startIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $colonIndex + 1, $colonIndex + 3, true);
+        if (!$startIndex) {
+            return;
+        }
+
+        $returnTokenType = $tokens[$startIndex]['type'];
+        if ($returnTokenType !== 'T_SELF') {
+            return;
+        }
+
+        if (!$this->isChainingMethod($phpcsFile, $stackPtr)) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError('Chaining methods (@return $this) should not have any return-type-hint (Remove "self").', $startIndex, 'TypeHint.Invalid.Self');
+        if (!$fix) {
+            return;
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+        for ($i = $colonIndex; $i <= $startIndex; $i++) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $stackPointer
+     *
+     * @return bool
+     */
+    protected function isChainingMethod(File $phpCsFile, int $stackPointer): bool
+    {
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
+
+        if (!$docBlockEndIndex) {
+            return false;
+        }
+
+        $tokens = $phpCsFile->getTokens();
+
+        $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
+
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
+            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+                continue;
+            }
+            if ($tokens[$i]['content'] !== '@return') {
+                continue;
+            }
+
+            $classNameIndex = $i + 2;
+
+            if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
+                continue;
+            }
+
+            $content = $tokens[$classNameIndex]['content'];
+            if (!$content) {
+                continue;
+            }
+
+            return $content === '$this';
+        }
+
+        return false;
+    }
+}

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -9,6 +9,7 @@ namespace Spryker\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 /**
@@ -237,6 +238,14 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
             $contentIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $i + 1, $scopeCloser, true);
             if (!$contentIndex) {
                 continue;
+            }
+
+            if ($tokens[$contentIndex]['code'] === T_PARENT) {
+                $parentMethodName = $tokens[$contentIndex + 2]['content'];
+
+                if ($parentMethodName === FunctionHelper::getName($phpCsFile, $stackPointer)) {
+                    continue;
+                }
             }
 
             $returnTypes[] = $tokens[$contentIndex]['content'];

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -255,7 +255,7 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
      */
     protected function assertChainableReturnType(File $phpCsFile, int $stackPointer, array $parts, array $returnTypes): void
     {
-        if ($parts === ['$this'] && $returnTypes !== ['$this']) {
+        if ($returnTypes && $parts === ['$this'] && $returnTypes !== ['$this']) {
             $phpCsFile->addError('Chainable method (@return $this) cannot have multiple return types in code.', $stackPointer, 'InvalidChainable');
         }
     }

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -230,6 +230,10 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
                 continue;
             }
 
+            if (in_array(T_CLOSURE, $tokens[$i]['conditions'])) {
+                continue;
+            }
+
             $contentIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $i + 1, $scopeCloser, true);
             if (!$contentIndex) {
                 continue;

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -78,7 +78,7 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
 
             $returnTypes = $this->getReturnTypes($phpCsFile, $stackPointer);
             $this->assertChainableReturnType($phpCsFile, $stackPointer, $parts, $returnTypes);
-            $this->fixClassToThis($phpCsFile, $stackPointer, $classNameIndex, $parts, $appendix, $returnTypes);
+            $this->fixClassToThis($phpCsFile, $classNameIndex, $parts, $appendix, $returnTypes);
         }
     }
 
@@ -162,15 +162,14 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param int $classNameIndex
-     * @param array $parts
+     * @param string[] $parts
      * @param string $appendix
-     * @param array $returnTypes
+     * @param string[] $returnTypes
      *
      * @return void
      */
-    protected function fixClassToThis(File $phpCsFile, int $stackPointer, int $classNameIndex, array $parts, string $appendix, array $returnTypes): void
+    protected function fixClassToThis(File $phpCsFile, int $classNameIndex, array $parts, string $appendix, array $returnTypes): void
     {
         $ownClassName = '\\' . $this->getClassName($phpCsFile);
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -238,7 +238,7 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
             $returnTypes[] = $tokens[$contentIndex]['content'];
         }
 
-        return $returnTypes;
+        return array_unique($returnTypes);
     }
 
     /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 157 sniffs
+The SprykerStrict standard contains 159 sniffs
 
 Generic (22 sniffs)
 -------------------
@@ -79,12 +79,13 @@ SlevomatCodingStandard (20 sniffs)
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Spryker (69 sniffs)
+Spryker (71 sniffs)
 -------------------
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
 - Spryker.Classes.MethodDeclaration
 - Spryker.Classes.MethodTypeHint
+- Spryker.Classes.ReturnTypeHint
 - Spryker.Commenting.DocBlock
 - Spryker.Commenting.DocBlockApiAnnotation
 - Spryker.Commenting.DocBlockConstructor
@@ -94,6 +95,7 @@ Spryker (69 sniffs)
 - Spryker.Commenting.DocBlockParamArray
 - Spryker.Commenting.DocBlockParamNotJustNull
 - Spryker.Commenting.DocBlockPipeSpacing
+- Spryker.Commenting.DocBlockReturnNullableType
 - Spryker.Commenting.DocBlockReturnSelf
 - Spryker.Commenting.DocBlockReturnTag
 - Spryker.Commenting.DocBlockReturnVoid


### PR DESCRIPTION
https://spryker.atlassian.net/browse/DT-795

The following is now detected as invalid (which wasnt so far):

```php
    /**
     * @return $this
     */
    public function doSth()
    {
        if ($this->doSthElse()) {
            return 'x';
        }

        return $this;
    }

    /**
     * @return $this
     */
    public function doSthMore(): self
    {
        return $this;
    }
```