### PR TITLE
DT-832 Add ModernClassNameReference sniff

### DIFF
--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -141,6 +141,7 @@
     <rule ref="PSR12.Namespaces.CompoundNamespaceDepth"/>
     <rule ref="PSR12.Operators.OperatorSpacing"/>
 
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
 
     <rule ref="Squiz.Scope.MemberVarScope"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 166 sniffs
+The SprykerStrict standard contains 167 sniffs
 
 Generic (23 sniffs)
 -------------------
@@ -64,10 +64,11 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (22 sniffs)
+SlevomatCodingStandard (23 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
+- SlevomatCodingStandard.Classes.ModernClassNameReference
 - SlevomatCodingStandard.Classes.UnusedPrivateElements
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment
 - SlevomatCodingStandard.Commenting.EmptyComment


### PR DESCRIPTION
As the other cases could soon be deprecated in PHP anyway and we should use one consistent way to use class reference now.