### PR TITLE
Use latest version of slevomat/coding-standard

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -231,7 +231,7 @@ abstract class AbstractSprykerSniff implements Sniff
      *
      * @return bool
      */
-    protected function contains(File $phpcsFile, $search, $start, $end, $skipNested = true): bool
+    protected function contains(File $phpcsFile, $search, int $start, int $end, bool $skipNested = true): bool
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "slevomat/coding-standard": "^4.8.3"
+    "slevomat/coding-standard": "^5.0.1"
   },
   "require-dev": {
     "dereuromark/composer-prefer-lowest": "^0.1.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "slevomat/coding-standard": "^5.0.1"
+    "slevomat/coding-standard": "^4.8.3 || ^5.0.1"
   },
   "require-dev": {
     "dereuromark/composer-prefer-lowest": "^0.1.2",


### PR DESCRIPTION
v4 => v5

it looks actually like we could use || even.