### PR TITLE
TE-1210 Added Slevomat rules

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -524,6 +524,7 @@ abstract class AbstractSprykerSniff implements Sniff
             if (!in_array($tokens[$i]['content'], ['@deprecated'])) {
                 continue;
             }
+
             return true;
         }
 

--- a/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -48,6 +48,7 @@ class ReturnTypeHintSniff extends AbstractSprykerSniff
 
         if (!$this->isChainingMethod($phpcsFile, $stackPtr)) {
             $this->assertNotThisOrStatic($phpcsFile, $stackPtr);
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/AbstractFileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/AbstractFileDocBlockSniff.php
@@ -79,6 +79,7 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
 
         if (!file_exists($path . '.license')) {
             $this->licenseMap[$path] = '';
+
             return '';
         }
 
@@ -215,6 +216,7 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
             if ($fix) {
                 $this->addFileDocBlock($phpCsFile, 0);
             }
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
@@ -95,6 +95,7 @@ class DocBlockParamSniff extends AbstractSprykerSniff
 
         if (count($docBlockParams) !== count($methodSignature)) {
             $phpCsFile->addError('Doc Block params do not match method signature', $stackPointer, 'SignatureMismatch');
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -78,6 +78,7 @@ class DocBlockReturnTagSniff extends AbstractScopeSniff
         if (!$commentWithReturn) {
             $error = 'Missing @return tag in function comment';
             $phpcsFile->addError($error, $stackPtr, 'Missing');
+
             return;
         }
 
@@ -88,6 +89,7 @@ class DocBlockReturnTagSniff extends AbstractScopeSniff
             if ($fixable) {
                 $phpcsFile->fixer->replaceToken($commentWithReturn, '');
             }
+
             return;
         }
     }

--- a/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
@@ -38,6 +38,7 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         $nextIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if ($tokens[$nextIndex]['content'] === '__construct' || $tokens[$nextIndex]['content'] === '__destruct') {
             $this->checkConstructorAndDestructor($phpcsFile, $nextIndex);
+
             return;
         }
 
@@ -63,6 +64,7 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
             if (!$docBlockReturnIndex && !$hasInheritDoc) {
                 $phpcsFile->addError('Method does not have a return statement in doc block: ' . $tokens[$nextIndex]['content'], $nextIndex, 'ReturnMissingInInterface');
             }
+
             return;
         }
 
@@ -76,11 +78,13 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
 
         if ($docBlockReturnIndex) {
             $this->assertExisting($phpcsFile, $stackPtr, $docBlockReturnIndex, $returnType);
+
             return;
         }
 
         if ($returnType === null) {
             $phpcsFile->addError('Method does not have a return statement in doc block: ' . $tokens[$nextIndex]['content'], $nextIndex, 'ReturnMissing');
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockSniff.php
@@ -40,6 +40,7 @@ class DocBlockSniff extends AbstractSprykerSniff
         $nextIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if ($tokens[$nextIndex]['content'] === '__construct' || $tokens[$nextIndex]['content'] === '__destruct') {
             $this->checkConstructorAndDestructor($phpcsFile, $stackPtr);
+
             return;
         }
 
@@ -58,6 +59,7 @@ class DocBlockSniff extends AbstractSprykerSniff
         $returnType = $this->detectReturnTypeVoid($phpcsFile, $stackPtr);
         if ($returnType === null) {
             $phpcsFile->addError('Method does not have a doc block: ' . $tokens[$nextIndex]['content'] . '()', $nextIndex, 'DocBlockMissing');
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
@@ -80,6 +80,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
         $prevIndex = $phpCsFile->findPrevious(T_DOC_COMMENT_STRING, $nextIndex - 1, $docBlockStartIndex + 1);
         if (!$prevIndex) {
             $this->checkBeginningOfDocBlock($phpCsFile, $docBlockStartIndex, $nextIndex);
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
@@ -87,6 +87,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
             if (!isset($order[$tag['tag']])) {
                 if ($currentOrder !== null) {
                     $tags[$i]['error'] = 'Position of ' . $tag['tag'] . ' tag too low.';
+
                     return $tags;
                 }
                 continue;

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -81,6 +81,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
 
         if (!$docCommentEndPosition) {
             $this->addCommentWithGroupAnnotation($phpCsFile, $stackPointer, $expectedGroupAnnotations);
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
@@ -71,6 +71,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
 
         if (!$docCommentEndPosition) {
             $this->addCommentWithGroupAnnotation($phpCsFile, $stackPointer, $namespaceParts);
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -76,6 +76,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
             }
 
             $phpCsFile->addError('Throw token found, but no annotation for it.', $docBlockEndIndex, 'ThrowAnnotationMissing');
+
             return;
         }
 
@@ -95,6 +96,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
         $error = 'Doc Block annotation @var for variable missing';
         if ($defaultValueType === null) {
             $phpCsFile->addError($error, $docBlockEndIndex, 'VarAnnotationMissing');
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -45,6 +45,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
 
         if (!$docBlockEndIndex) {
             $phpCsFile->addError('Doc Block for variable missing', $stackPointer, 'VarDocBlockMissing');
+
             return;
         }
 
@@ -66,6 +67,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
 
         if (!$varIndex) {
             $this->handleMissingVar($phpCsFile, $docBlockEndIndex, $docBlockStartIndex, $defaultValueType);
+
             return;
         }
 
@@ -73,6 +75,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
 
         if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
             $this->handleMissingVarType($phpCsFile, $varIndex, $defaultValueType);
+
             return;
         }
 
@@ -91,6 +94,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
                 $error .= ', type `' . $defaultValueType . '` detected';
             }
             $phpCsFile->addError($error, $stackPointer, 'VarTypeEmpty');
+
             return;
         }
 
@@ -111,6 +115,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
             if ($fix) {
                 $phpCsFile->fixer->replaceToken($classNameIndex, implode('|', $parts) . '|' . $defaultValueType . $appendix);
             }
+
             return;
         }
 
@@ -186,6 +191,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
         $error = 'Doc Block annotation @var for variable missing';
         if ($defaultValueType === null) {
             $phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockMissing');
+
             return;
         }
 
@@ -218,6 +224,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
         $error = 'Doc Block type for annotation @var for variable missing';
         if ($defaultValueType === null) {
             $phpCsFile->addError($error, $varIndex, 'VarTypeMissing');
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -32,6 +32,7 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
     {
         if (!$this->isSprykerNamespace($phpCsFile, $stackPointer) || $this->isIgnorableBundle($phpCsFile)) {
             $this->checkCustomFileDocBlock($phpCsFile, $stackPointer);
+
             return;
         }
 
@@ -46,6 +47,7 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
             } else {
                 $this->addFixableMissingDocBlock($phpCsFile, $stackPointer);
             }
+
             return;
         }
 
@@ -64,6 +66,7 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
             if ($fix) {
                 $this->addCustomFileDocBlock($phpCsFile, 0, $customLicense);
             }
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -134,6 +134,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
 
             if ($typeTag === null || $contentTag === null) {
                 $phpCsFile->addError('Invalid Inline Doc Block', $startIndex, 'DocBlockInvalid');
+
                 return;
             }
 
@@ -205,6 +206,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         preg_match('|^(.+?)(\s+)(.+?)\s*$|', $comment, $contentMatches);
         if (!$contentMatches || !$contentMatches[1] || !$contentMatches[3]) {
             $phpCsFile->addError('Invalid Inline Doc Block content', $contentIndex, 'ContentInvalid');
+
             return [];
         }
 

--- a/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
@@ -52,6 +52,7 @@ class SprykerConstantsSniff extends AbstractFileDocBlockSniff
 
         if (!$docBlockEndIndex) {
             $this->addNewDocBlock($phpCsFile, $stackPointer);
+
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/SprykerFacadeSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerFacadeSniff.php
@@ -36,6 +36,7 @@ class SprykerFacadeSniff implements Sniff
 
         if ($this->isFacadeInterface($phpCsFile, $stackPointer)) {
             $this->checkInterface($phpCsFile, $stackPointer);
+
             return;
         }
 

--- a/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
@@ -58,6 +58,7 @@ class ConditionalExpressionOrderSniff implements Sniff
         ) {
             // Not fixable
             $phpCsFile->addError($error, $stackPointer, 'YodaNotAllowed');
+
             return;
         }
 

--- a/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -96,6 +96,7 @@ class ControlStructureSpacingSniff implements Sniff
             if ($fix) {
                 $phpcsFile->fixer->addContent($prevIndex, ' ');
             }
+
             return;
         }
 
@@ -128,6 +129,7 @@ class ControlStructureSpacingSniff implements Sniff
             if ($fix) {
                 $phpcsFile->fixer->addContent($stackPtr, ' ');
             }
+
             return;
         }
 

--- a/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
+++ b/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
@@ -35,6 +35,7 @@ class NoInlineAssignmentSniff extends AbstractSprykerSniff
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$stackPtr]['code'] === T_OBJECT_OPERATOR || $tokens[$stackPtr]['code'] === T_DOUBLE_COLON) {
             $this->checkMethodCalls($phpcsFile, $stackPtr);
+
             return;
         }
 

--- a/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
@@ -66,6 +66,7 @@ class SprykerNoDemoshopSniff extends AbstractSprykerSniff
         $file = substr($phpCsFile->getFilename(), 0, $positionSprykerCore) . '/composer.json';
         if (!is_file($file)) {
             static::$isDemoshop = false;
+
             return static::$isDemoshop;
         }
 

--- a/Spryker/Sniffs/PHP/NoIsNullSniff.php
+++ b/Spryker/Sniffs/PHP/NoIsNullSniff.php
@@ -62,6 +62,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
             $anotherPossibleCastIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($possibleCastIndex - 1), null, true);
             if ($tokens[$anotherPossibleCastIndex]['code'] === T_BOOLEAN_NOT) {
                 $phpcsFile->addError($error, $stackPtr, 'DoubleNot');
+
                 return;
             }
         }
@@ -69,6 +70,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
         // We don't want to fix stuff with bad inline assignment
         if ($this->contains($phpcsFile, 'T_EQUAL', $openingBraceIndex + 1, $closingBraceIndex - 1)) {
             $phpcsFile->addError($error, $stackPtr, 'NoInlineAssignment');
+
             return;
         }
 

--- a/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -69,6 +69,7 @@ class CommaSpacingSniff implements Sniff
             if ($fix) {
                 $phpcsFile->fixer->replaceToken($stackPtr, '');
             }
+
             return;
         }
 

--- a/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
@@ -38,6 +38,7 @@ class EmptyEnclosingLineSniff implements Sniff
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
             $error = 'Possible parse error: %s missing opening or closing brace';
             $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
+
             return;
         }
 
@@ -66,6 +67,7 @@ class EmptyEnclosingLineSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }
+
             return;
         }
 

--- a/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -33,6 +33,7 @@ class ImplicitCastSpacingSniff implements Sniff
 
         if ($tokens[$stackPtr]['code'] === T_INC || $tokens[$stackPtr]['code'] === T_DEC) {
             $this->processIncDec($phpcsFile, $stackPtr);
+
             return;
         }
 
@@ -72,6 +73,7 @@ class ImplicitCastSpacingSniff implements Sniff
                 $phpcsFile->fixer->replaceToken($stackPtr + 1, '');
                 $phpcsFile->fixer->endChangeset();
             }
+
             return;
         }
 
@@ -87,6 +89,7 @@ class ImplicitCastSpacingSniff implements Sniff
                 $phpcsFile->fixer->replaceToken($stackPtr - 1, '');
                 $phpcsFile->fixer->endChangeset();
             }
+
             return;
         }
     }

--- a/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
@@ -66,6 +66,7 @@ class MethodSpacingSniff extends AbstractSprykerSniff
         $nextContentIndex = $phpcsFile->findNext(T_WHITESPACE, ($braceStartIndex + 1), null, true);
         if ($nextContentIndex === $braceEndIndex) {
             $this->assertNoAdditionalNewlinesForEmptyBody($phpcsFile, $braceStartIndex, $braceEndIndex);
+
             return;
         }
 

--- a/Spryker/Tools/Tokenizer.php
+++ b/Spryker/Tools/Tokenizer.php
@@ -145,6 +145,7 @@ class Tokenizer
         if ($this->verbose) {
             return $pieces;
         }
+
         return [implode(' ', $pieces)];
     }
 }

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -54,6 +54,15 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
 
+    <rule ref="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing.IncorrectLinesCountBeforeControlStructure"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing">
+        <properties>
+            <property name="tokensToCheck" type="array">
+                <element value="T_RETURN"/>
+            </property>
+        </properties>
+    </rule>
+
     <rule ref="Generic.WhiteSpace.ScopeIndent">
         <properties>
             <property name="ignoreIndentationTokens" type="array" value="T_COMMENT,T_DOC_COMMENT_OPEN_TAG"/>


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-1210

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CodeSniffer           | patch (currently 0.x)  |                       |

#### Release Notes

Added new rules from slevomat which add an empty line before control structures.

-----------------------------------------

#### Module CodeSniffer

##### Change log

### Improvement

- Added new rules from slevomat which add an empty line before control structures.

