### PR TITLE
Bugfix/variable null type last

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -100,14 +100,8 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
             $content .= $appendix;
         }
 
-        $error = 'Doc Block annotation @var for variable null is in wrong order';
-        if ($content === null) {
-            $phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockWrongOrder');
-
-            return;
-        }
-
-        $error .= ', type `' . $content . '` expected.';
+        $error = 'Doc Block annotation @var for type `null` has a wrong order';
+        $error .= ', `' . $content . '` expected.';
         $fix = $phpCsFile->addFixableError($error, $docBlockEndIndex, 'WrongType');
         if (!$fix) {
             return;

--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -80,7 +80,7 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
             return;
         }
 
-        $this->handleMissingVar($phpCsFile, $docBlockEndIndex, $commentStringIndex, $content, $appendix);
+        $this->handleInvalidOrder($phpCsFile, $docBlockEndIndex, $commentStringIndex, $content, $appendix);
     }
 
     /**
@@ -92,7 +92,7 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
      *
      * @return void
      */
-    protected function handleMissingVar(File $phpCsFile, int $docBlockEndIndex, int $commentStringIndex, string $content, string $appendix): void
+    protected function handleInvalidOrder(File $phpCsFile, int $docBlockEndIndex, int $commentStringIndex, string $content, string $appendix): void
     {
         $content = str_replace('null|', '', $content) . '|null';
         $content = implode('|', array_unique(explode('|', $content)));

--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+
+/**
+ * Ensures Doc Blocks for variables contains the nullable type hint last.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
+{
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [
+            T_VARIABLE,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpCsFile, $stackPointer)
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
+        if (!$docBlockEndIndex) {
+            return;
+        }
+        $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
+
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
+            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+                continue;
+            }
+
+            if ($tokens[$i]['content'] === '@var') {
+                $this->fixVarHint($phpCsFile, $i, $docBlockEndIndex);
+                break;
+            }
+        }
+
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $varCommentTagIndex
+     * @param int $docBlockEndIndex
+     *
+     * @return void
+     */
+    protected function fixVarHint(File $phpCsFile, int $varCommentTagIndex, int $docBlockEndIndex): void
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        
+    }
+
+    /**
+     * @param array $token
+     *
+     * @return string|null
+     */
+    protected function detectType(array $token): ?string
+    {
+        if ($this->isGivenKind(T_OPEN_SHORT_ARRAY, $token)) {
+            return 'array';
+        }
+
+        if ($this->isGivenKind(T_LNUMBER, $token)) {
+            return 'int';
+        }
+
+        if ($this->isGivenKind(T_CONSTANT_ENCAPSED_STRING, $token)) {
+            return 'string';
+        }
+
+        if ($this->isGivenKind([T_FALSE, T_TRUE], $token)) {
+            return 'bool';
+        }
+
+        if ($this->isGivenKind(T_NULL, $token)) {
+            return 'null';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $docBlockEndIndex
+     * @param int $docBlockStartIndex
+     * @param string|null $defaultValueType
+     *
+     * @return void
+     */
+    protected function handleMissingVar(File $phpCsFile, int $docBlockEndIndex, int $docBlockStartIndex, ?string $defaultValueType): void
+    {
+        $error = 'Doc Block annotation @var for variable missing';
+        if ($defaultValueType === null) {
+            $phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockMissing');
+
+            return;
+        }
+
+        $error .= ', type `' . $defaultValueType . '` detected';
+        $fix = $phpCsFile->addFixableError($error, $docBlockEndIndex, 'WrongType');
+        if (!$fix) {
+            return;
+        }
+
+        $index = $phpCsFile->findPrevious(Tokens::$emptyTokens, $docBlockEndIndex - 1, $docBlockStartIndex, true);
+        if (!$index) {
+            $index = $docBlockStartIndex;
+        }
+
+        $phpCsFile->fixer->beginChangeset();
+        $phpCsFile->fixer->addNewline($index);
+        $phpCsFile->fixer->addContent($index, "\t" . ' * @var ' . $defaultValueType);
+        $phpCsFile->fixer->endChangeset();
+    }
+}

--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -12,7 +12,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 /**
- * Ensures Doc Blocks for variables contains the nullable type hint last.
+ * Ensures Doc Blocks for class properties contains the nullable type hint last.
  *
  * @author Mark Scherer
  * @license MIT
@@ -66,7 +66,7 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
     {
         $tokens = $phpCsFile->getTokens();
 
-        
+
     }
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -80,42 +80,41 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
             return;
         }
 
-        $content = str_replace('null|', '', $content) . '|null';
-        $content = implode('|', array_unique(explode('|', $content)));
-
-        if ($appendix) {
-            $content .= $appendix;
-        }
-
-        $this->handleMissingVar($phpCsFile, $docBlockEndIndex, $commentStringIndex, $content, $content);
+        $this->handleMissingVar($phpCsFile, $docBlockEndIndex, $commentStringIndex, $content, $appendix);
     }
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $docBlockEndIndex
      * @param int $commentStringIndex
-     * @param string $correctedOrderCommentStringValue
-     * @param string|null $wrongOrderCommentStringValue
+     * @param string $content
+     * @param string $appendix
      *
      * @return void
      */
-    protected function handleMissingVar(File $phpCsFile, int $docBlockEndIndex, int $commentStringIndex, string $correctedOrderCommentStringValue, ?string $wrongOrderCommentStringValue): void
+    protected function handleMissingVar(File $phpCsFile, int $docBlockEndIndex, int $commentStringIndex, string $content, string $appendix): void
     {
+        $content = str_replace('null|', '', $content) . '|null';
+        $content = implode('|', array_unique(explode('|', $content)));
+        if ($appendix) {
+            $content .= $appendix;
+        }
+
         $error = 'Doc Block annotation @var for variable null is in wrong order';
-        if ($wrongOrderCommentStringValue === null) {
+        if ($content === null) {
             $phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockWrongOrder');
 
             return;
         }
 
-        $error .= ', type `' . $wrongOrderCommentStringValue . '` detected';
+        $error .= ', type `' . $content . '` expected.';
         $fix = $phpCsFile->addFixableError($error, $docBlockEndIndex, 'WrongType');
         if (!$fix) {
             return;
         }
 
         $phpCsFile->fixer->beginChangeset();
-        $phpCsFile->fixer->replaceToken($commentStringIndex, $correctedOrderCommentStringValue);
+        $phpCsFile->fixer->replaceToken($commentStringIndex, $content);
         $phpCsFile->fixer->endChangeset();
     }
 }


### PR DESCRIPTION
This fixed the `var null|x` order issue, now the `null` type will come at last:
```
/**
 * @var string|null
 */
protected $organization;
```