### PR TITLE
Remove invalid skips.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![License](https://poser.pugx.org/spryker/code-sniffer/license.svg)](https://packagist.org/packages/spryker/code-sniffer)
 [![Total Downloads](https://poser.pugx.org/spryker/code-sniffer/d/total.svg)](https://packagist.org/packages/spryker/code-sniffer)
 
-This sniffer package follows [PSR-2](http://www.php-fig.org/psr/psr-2/) completely and ships with a lot of additional fixers on top (incl PSR-12).
+This sniffer package follows [PSR-2](http://www.php-fig.org/psr/psr-2/) completely and ships with a lot of additional fixers on top (incl. PSR-12).
 Please see the Spryker Coding conventions for details.
 
-[List of included sniffs](/docs)
+[List of included sniffs.](/docs)
 
 ## Documentation
 https://github.com/squizlabs/PHP_CodeSniffer/wiki

--- a/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
@@ -24,9 +24,9 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
     protected $fileExists = false;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_CLASS,
@@ -46,7 +46,7 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
     abstract protected function getMethodFileAddedName(File $phpCsFile): string;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -153,7 +153,7 @@ abstract class AbstractSprykerSniff implements Sniff
     {
         $useStatements = $this->parseUseStatements($phpCsFile, $stackPointer);
         foreach ($missingUses as $missingUse) {
-            if (!in_array($missingUse, $useStatements)) {
+            if (!in_array($missingUse, $useStatements, true)) {
                 $this->addMissingUse($phpCsFile, $stackPointer, $missingUse);
             }
         }
@@ -163,7 +163,7 @@ abstract class AbstractSprykerSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return array
+     * @return string[]
      */
     protected function parseUseStatements(File $phpCsFile, int $stackPointer): array
     {
@@ -521,7 +521,7 @@ abstract class AbstractSprykerSniff implements Sniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@deprecated'])) {
+            if (!in_array($tokens[$i]['content'], ['@deprecated'], true)) {
                 continue;
             }
 
@@ -535,7 +535,7 @@ abstract class AbstractSprykerSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return array
+     * @return string[]
      */
     protected function getDocBlockReturnTypes(File $phpCsFile, int $stackPointer): array
     {

--- a/Spryker/Sniffs/Classes/ClassFileNameSniff.php
+++ b/Spryker/Sniffs/Classes/ClassFileNameSniff.php
@@ -28,9 +28,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class ClassFileNameSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_CLASS,
@@ -39,7 +39,7 @@ class ClassFileNameSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Classes/MethodArgumentDefaultValueSniff.php
+++ b/Spryker/Sniffs/Classes/MethodArgumentDefaultValueSniff.php
@@ -21,15 +21,15 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Classes/MethodTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/MethodTypeHintSniff.php
@@ -19,15 +19,15 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class MethodTypeHintSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -19,15 +19,15 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class ReturnTypeHintSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Commenting/AbstractFileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/AbstractFileDocBlockSniff.php
@@ -19,7 +19,7 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
     protected const YEAR = '2016';
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $sprykerNamespaces = [
         'Spryker',
@@ -29,7 +29,7 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
     ];
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $sprykerTestNamespaces = [
         'SprykerTest',
@@ -39,7 +39,7 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
     ];
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $sprykerApplications = [
         'Client',
@@ -52,12 +52,12 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
     /**
      * Cache of licenses to avoid file lookups.
      *
-     * @var array
+     * @var string[]
      */
     protected $licenseMap = [];
 
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {
@@ -107,8 +107,8 @@ abstract class AbstractFileDocBlockSniff extends AbstractSprykerSniff
             }
 
             $secondNamespaceString = $phpCsFile->getTokens()[$secondNamespaceTokenPosition]['content'];
-            $isSprykerClass = (in_array($firstNamespaceString, $this->sprykerNamespaces) && in_array($secondNamespaceString, $this->sprykerApplications));
-            $isSprykerTestClass = in_array($firstNamespaceString, $this->sprykerTestNamespaces) && in_array($secondNamespaceString, $this->sprykerApplications);
+            $isSprykerClass = (in_array($firstNamespaceString, $this->sprykerNamespaces, true) && in_array($secondNamespaceString, $this->sprykerApplications, true));
+            $isSprykerTestClass = in_array($firstNamespaceString, $this->sprykerTestNamespaces, true) && in_array($secondNamespaceString, $this->sprykerApplications, true);
 
             return ($isSprykerClass || $isSprykerTestClass);
         }

--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class DocBlockApiAnnotationSniff implements Sniff
 {
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {

--- a/Spryker/Sniffs/Commenting/DocBlockConstructorSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstructorSniff.php
@@ -22,7 +22,7 @@ class DocBlockConstructorSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }

--- a/Spryker/Sniffs/Commenting/DocBlockNoInlineAlignmentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockNoInlineAlignmentSniff.php
@@ -16,9 +16,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class DocBlockNoInlineAlignmentSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_DOC_COMMENT_TAG,
@@ -27,7 +27,7 @@ class DocBlockNoInlineAlignmentSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -27,7 +27,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -59,7 +59,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@param'])) {
+            if (!in_array($tokens[$i]['content'], ['@param'], true)) {
                 continue;
             }
 
@@ -98,7 +98,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            if ($methodSignatureValue['typehint'] && in_array($methodSignatureValue['typehint'], ['array', 'string', 'int', 'bool', 'float', 'self', 'parent'])) {
+            if ($methodSignatureValue['typehint'] && in_array($methodSignatureValue['typehint'], ['array', 'string', 'int', 'bool', 'float', 'self', 'parent'], true)) {
                 $type = $methodSignatureValue['typehint'];
                 if (!$this->containsType($type, $pieces) && ($type !== 'array' || !$this->containsTypeArray($pieces))) {
                     $pieces[] = $type;
@@ -113,7 +113,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             if ($methodSignatureValue['default']) {
                 $type = $methodSignatureValue['default'];
 
-                if (!in_array($type, $pieces) && ($type !== 'array' || !$this->containsTypeArray($pieces))) {
+                if (!in_array($type, $pieces, true) && ($type !== 'array' || !$this->containsTypeArray($pieces))) {
                     $pieces[] = $type;
                     $error = 'Possible doc block error: `' . $content . '` seems to be missing type `' . $type . '`.';
                     $fix = $phpCsFile->addFixableError($error, $classNameIndex, 'Default');
@@ -127,7 +127,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             if ($methodSignatureValue['nullable']) {
                 $type = 'null';
 
-                if (!in_array($type, $pieces)) {
+                if (!in_array($type, $pieces, true)) {
                     $pieces[] = $type;
                     $error = 'Doc block error: `' . $content . '` seems to be missing type `' . $type . '`.';
                     $fix = $phpCsFile->addFixableError($error, $classNameIndex, 'Default');
@@ -140,7 +140,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
 
             if (!$methodSignatureValue['default'] && !$methodSignatureValue['nullable']) {
                 $error = 'Doc block error: `' . $content . '` seems to be having a wrong `null` type hinted, argument is not nullable though.';
-                if (in_array('null', $pieces)) {
+                if (in_array('null', $pieces, true)) {
                     $fix = $phpCsFile->addFixableError($error, $classNameIndex, 'WrongNullable');
                     if ($fix) {
                         foreach ($pieces as $k => $v) {
@@ -158,13 +158,13 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
 
     /**
      * @param string $type
-     * @param array $pieces
+     * @param string[] $pieces
      *
      * @return bool
      */
     protected function containsType(string $type, array $pieces): bool
     {
-        if (in_array($type, $pieces)) {
+        if (in_array($type, $pieces, true)) {
             return true;
         }
         $longTypes = [
@@ -177,6 +177,6 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
 
         $longType = $longTypes[$type];
 
-        return in_array($longType, $pieces);
+        return in_array($longType, $pieces, true);
     }
 }

--- a/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
@@ -47,10 +47,6 @@ class DocBlockParamArraySniff extends AbstractSprykerSniff
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
-        if ($this->hasInheritDoc($phpCsFile, $docBlockStartIndex, $docBlockEndIndex)) {
-            return;
-        }
-
         for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;

--- a/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
@@ -25,7 +25,7 @@ class DocBlockParamArraySniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,

--- a/Spryker/Sniffs/Commenting/DocBlockParamNotJustNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamNotJustNullSniff.php
@@ -26,7 +26,7 @@ class DocBlockParamNotJustNullSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -58,7 +58,7 @@ class DocBlockParamNotJustNullSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@param'])) {
+            if (!in_array($tokens[$i]['content'], ['@param'], true)) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
@@ -62,7 +62,7 @@ class DocBlockParamSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@param'])) {
+            if (!in_array($tokens[$i]['content'], ['@param'], true)) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
@@ -26,7 +26,7 @@ class DocBlockParamSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,

--- a/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
@@ -16,9 +16,9 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class DocBlockPipeSpacingSniff implements Sniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_DOC_COMMENT_STRING,
@@ -26,7 +26,7 @@ class DocBlockPipeSpacingSniff implements Sniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
@@ -15,7 +15,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function register(): array
     {
@@ -25,7 +25,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {
@@ -47,7 +47,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
             return;
         }
 
-        if (in_array('null', $docBlockReturnTypes)) {
+        if (in_array('null', $docBlockReturnTypes, true)) {
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -19,9 +19,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class DocBlockReturnSelfSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -29,7 +29,7 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 class DocBlockReturnTagSniff extends AbstractScopeSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function __construct()
     {
@@ -35,7 +35,7 @@ class DocBlockReturnTagSniff extends AbstractScopeSniff
         $tokens = $phpcsFile->getTokens();
 
         $method = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
-        $returnRequired = !in_array($tokens[$method]['content'], ['__construct', '__destruct']);
+        $returnRequired = !in_array($tokens[$method]['content'], ['__construct', '__destruct'], true);
 
         $find = [
         T_COMMENT,

--- a/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
@@ -23,7 +23,7 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }

--- a/Spryker/Sniffs/Commenting/DocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockSniff.php
@@ -25,7 +25,7 @@ class DocBlockSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }

--- a/Spryker/Sniffs/Commenting/DocBlockStructureSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockStructureSniff.php
@@ -23,7 +23,7 @@ class DocBlockStructureSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_DOC_COMMENT_OPEN_TAG,

--- a/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
@@ -26,7 +26,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
@@ -51,7 +51,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
-        $hasInheritDoc = $this->hasInheritDoc($phpCsFile, $docBlockStartIndex, $docBlockEndIndex, '{@inheritdoc}');
+        $hasInheritDoc = $this->hasInheritDoc($phpCsFile, $docBlockStartIndex, $docBlockEndIndex, '{@inheritDoc}');
         if ($hasInheritDoc) {
             return;
         }

--- a/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
@@ -37,7 +37,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -20,7 +20,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     protected const ANNOTATION_END_TEXT = 'Add your own group annotations below this line';
 
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {
@@ -65,7 +65,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param array $expectedGroupAnnotations
+     * @param string[] $expectedGroupAnnotations
      *
      * @return void
      */
@@ -91,7 +91,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param array $expectedAnnotations
+     * @param string[] $expectedAnnotations
      *
      * @return void
      */
@@ -125,7 +125,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $docCommentEndPosition
-     * @param array $namespaceParts
+     * @param string[] $namespaceParts
      *
      * @return void
      */
@@ -157,7 +157,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return array
+     * @return string[]
      */
     protected function getNamespaceParts(File $phpCsFile, int $stackPointer): array
     {
@@ -192,7 +192,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return array
+     * @return string[]
      */
     protected function getAnnotations(File $phpCsFile, int $stackPointer): array
     {
@@ -225,9 +225,9 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $namespaceParts
+     * @param string[] $namespaceParts
      *
-     * @return array
+     * @return string[]
      */
     protected function getExpectedAnnotations(File $phpCsFile, array $namespaceParts): array
     {
@@ -327,8 +327,8 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $givenGroupAnnotationParts
-     * @param array $expectedGroupAnnotations
+     * @param string[] $givenGroupAnnotationParts
+     * @param string[] $expectedGroupAnnotations
      *
      * @return bool
      */

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
@@ -17,7 +17,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
 {
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {
@@ -153,7 +153,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return array
+     * @return string[]
      */
     protected function getNamespaceParts(File $phpCsFile, int $stackPointer): array
     {

--- a/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -27,7 +27,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -57,10 +57,6 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
         $tokens = $phpCsFile->getTokens();
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
-        if ($this->hasInheritDoc($phpCsFile, $docBlockStartIndex, $docBlockEndIndex)) {
-            return;
-        }
-
         $docBlockParams = $this->getDocBlockParams($tokens, $docBlockStartIndex, $docBlockEndIndex);
 
         $this->assertOrder($phpCsFile, $docBlockParams);

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -37,7 +37,7 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -158,7 +158,7 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@param', '@return'])) {
+            if (!in_array($tokens[$i]['content'], ['@param', '@return'], true)) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVarNotJustNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarNotJustNullSniff.php
@@ -22,7 +22,7 @@ class DocBlockVarNotJustNullSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_VARIABLE,
@@ -58,7 +58,7 @@ class DocBlockVarNotJustNullSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@var'])) {
+            if (!in_array($tokens[$i]['content'], ['@var'], true)) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -22,7 +22,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_VARIABLE,
@@ -62,7 +62,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@var'])) {
+            if (!in_array($tokens[$i]['content'], ['@var'], true)) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -21,7 +21,7 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_VARIABLE,

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -21,12 +21,12 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
     /**
      * This property can be filled within the ruleset configuration file
      *
-     * @var array
+     * @var string[]
      */
     public $ignorableBundles = [];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {
@@ -96,7 +96,7 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
      */
     protected function isIgnorableBundle(File $phpCsFile): bool
     {
-        return (in_array($this->getModule($phpCsFile), $this->ignorableBundles));
+        return (in_array($this->getModule($phpCsFile), $this->ignorableBundles, true));
     }
 
     /**

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class FullyQualifiedClassNameInDocBlockSniff implements Sniff
 {
     /**
-     * @var array
+     * @var string[]
      */
     public static $whitelistedTypes = [
         'string', 'int', 'integer', 'float', 'bool', 'boolean', 'resource', 'null', 'void', 'callable',
@@ -24,9 +24,9 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     ];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_CLASS,
@@ -39,7 +39,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {
@@ -57,7 +57,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@return', '@param', '@throws', '@var', '@method', '@property'])) {
+            if (!in_array($tokens[$i]['content'], ['@return', '@param', '@throws', '@var', '@method', '@property'], true)) {
                 continue;
             }
 
@@ -133,7 +133,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
                 $arrayOfObject++;
                 $className = substr($className, 0, -2);
             }
-            if (in_array($className, static::$whitelistedTypes)) {
+            if (in_array($className, static::$whitelistedTypes, true)) {
                 continue;
             }
             $useStatement = $this->findUseStatementForClassName($phpCsFile, $className);
@@ -259,7 +259,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      *
-     * @return array
+     * @return string[]
      */
     protected function parseUseStatements(File $phpCsFile): array
     {

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -16,9 +16,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class InlineDocBlockSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -26,7 +26,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {
@@ -195,7 +195,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $contentIndex
      *
-     * @return array
+     * @return string[]
      */
     protected function findErrors(File $phpCsFile, int $contentIndex): array
     {

--- a/Spryker/Sniffs/Commenting/SprykerAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerAnnotationSniff.php
@@ -16,7 +16,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class SprykerAnnotationSniff extends AbstractSprykerSniff
 {
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {

--- a/Spryker/Sniffs/Commenting/SprykerBridgeSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerBridgeSniff.php
@@ -19,7 +19,7 @@ class SprykerBridgeSniff implements Sniff
     use BridgeTrait;
 
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {

--- a/Spryker/Sniffs/Commenting/SprykerFacadeSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerFacadeSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class SprykerFacadeSniff implements Sniff
 {
     /**
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {

--- a/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
@@ -20,15 +20,15 @@ class ConditionalExpressionOrderSniff implements Sniff
     use BasicsTrait;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return Tokens::$comparisonTokens;
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -18,7 +18,7 @@ class ControlStructureSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             //T_IF,

--- a/Spryker/Sniffs/DependencyProvider/FacadeNotInBridgeReturnedSniff.php
+++ b/Spryker/Sniffs/DependencyProvider/FacadeNotInBridgeReturnedSniff.php
@@ -18,9 +18,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_CLOSURE,
@@ -28,7 +28,7 @@ class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/Factory/CreateVsGetMethodsSniff.php
+++ b/Spryker/Sniffs/Factory/CreateVsGetMethodsSniff.php
@@ -17,9 +17,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class CreateVsGetMethodsSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -27,7 +27,7 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/Factory/NoPrivateMethodsSniff.php
+++ b/Spryker/Sniffs/Factory/NoPrivateMethodsSniff.php
@@ -19,9 +19,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class NoPrivateMethodsSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -29,7 +29,7 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/Factory/OneNewPerMethodSniff.php
+++ b/Spryker/Sniffs/Factory/OneNewPerMethodSniff.php
@@ -18,9 +18,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class OneNewPerMethodSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_FUNCTION,
@@ -28,7 +28,7 @@ class OneNewPerMethodSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {

--- a/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
+++ b/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
@@ -25,9 +25,9 @@ use PHP_CodeSniffer\Util\Tokens;
 class ArrayDeclarationSniff implements Sniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_OPEN_SHORT_ARRAY,
@@ -35,7 +35,7 @@ class ArrayDeclarationSniff implements Sniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
@@ -21,15 +21,15 @@ class SprykerNoDemoshopSniff extends AbstractSprykerSniff
     protected static $isDemoshop = null;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_NAMESPACE];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
@@ -16,15 +16,15 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class FunctionNamespaceSniff implements Sniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -19,15 +19,15 @@ class SprykerNamespaceSniff implements Sniff
     use BasicsTrait;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_INTERFACE];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
@@ -33,15 +33,15 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
     ];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_INTERFACE, T_TRAIT];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -21,15 +21,15 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
     protected const NAMESPACE_PROJECT = 'Pyz';
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_INTERFACE, T_TRAIT];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Namespaces/UseStatementSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseStatementSniff.php
@@ -41,15 +41,15 @@ class UseStatementSniff implements Sniff
     protected $className;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_NEW, T_FUNCTION, T_DOUBLE_COLON, T_CLASS, T_INTERFACE, T_TRAIT, T_INSTANCEOF, T_CATCH, T_CLOSURE];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/Namespaces/UseWithAliasingSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseWithAliasingSniff.php
@@ -19,15 +19,15 @@ class UseWithAliasingSniff extends AbstractSprykerSniff
     use UseStatementsTrait;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_AS];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/PHP/NoIsNullSniff.php
+++ b/Spryker/Sniffs/PHP/NoIsNullSniff.php
@@ -17,15 +17,15 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class NoIsNullSniff extends AbstractSprykerSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/PHP/NotEqualSniff.php
+++ b/Spryker/Sniffs/PHP/NotEqualSniff.php
@@ -23,15 +23,15 @@ class NotEqualSniff implements Sniff
     ];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_IS_NOT_EQUAL];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -18,15 +18,15 @@ class PhpSapiConstantSniff implements Sniff
     protected const PHP_SAPI = 'PHP_SAPI';
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
+++ b/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
@@ -26,15 +26,15 @@ class PreferCastOverFunctionSniff extends AbstractSprykerSniff
     ];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -38,15 +38,15 @@ class RemoveFunctionAliasSniff implements Sniff
     ];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/PHP/ShortCastSniff.php
+++ b/Spryker/Sniffs/PHP/ShortCastSniff.php
@@ -24,15 +24,15 @@ class ShortCastSniff implements Sniff
     ];
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_BOOL_CAST, T_INT_CAST, T_BOOLEAN_NOT];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -21,7 +21,7 @@ class CommaSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_COMMA];
     }

--- a/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
@@ -29,7 +29,7 @@ class ConcatenationSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING_CONCAT];
     }

--- a/Spryker/Sniffs/WhiteSpace/DocBlockSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/DocBlockSpacingSniff.php
@@ -21,7 +21,7 @@ class DocBlockSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_INTERFACE, T_TRAIT, T_FUNCTION, T_PROPERTY];
     }

--- a/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
@@ -16,9 +16,9 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class EmptyEnclosingLineSniff implements Sniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_CLASS,
@@ -28,7 +28,7 @@ class EmptyEnclosingLineSniff implements Sniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -32,7 +32,7 @@ class EmptyLinesSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_WHITESPACE];
     }

--- a/Spryker/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -17,15 +17,15 @@ use PHP_CodeSniffer\Util\Tokens;
 class FunctionSpacingSniff implements Sniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpCsFile, $stackPointer)
     {
@@ -65,7 +65,7 @@ class FunctionSpacingSniff implements Sniff
 
         // Ignore closures
         $nextIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $closingBraceIndex + 1, null, true);
-        if (in_array($tokens[$nextIndex]['content'], [';', ',', ')'])) {
+        if (in_array($tokens[$nextIndex]['content'], [';', ',', ')'], true)) {
             return;
         }
 

--- a/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -17,15 +17,15 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class ImplicitCastSpacingSniff implements Sniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_BOOLEAN_NOT, T_NONE, T_ASPERAND, T_INC, T_DEC];
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
 class MemberVarSpacingSniff extends AbstractVariableSniff
 {
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function processMemberVar(File $phpcsFile, $stackPtr)
     {
@@ -64,7 +64,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function processVariable(File $phpcsFile, $stackPtr)
     {
@@ -72,7 +72,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function processVariableInString(File $phpcsFile, $stackPtr)
     {

--- a/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
@@ -21,7 +21,7 @@ class MethodSpacingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }

--- a/Spryker/Sniffs/WhiteSpace/ObjectAttributeSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ObjectAttributeSpacingSniff.php
@@ -21,7 +21,7 @@ class ObjectAttributeSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_OBJECT_OPERATOR, T_DOUBLE_COLON];
     }

--- a/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -30,7 +30,7 @@ class OperatorSpacingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function register()
+    public function register(): array
     {
         $comparison = Tokens::$comparisonTokens;
         $operators = Tokens::$operators;

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -145,10 +145,7 @@
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
     <rule ref="Generic.PHP.LowerCaseType"/>
 
-    <rule ref="PSR12.Classes.ClassInstantiation"/>
-    <rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
-    <rule ref="PSR12.Namespaces.CompoundNamespaceDepth"/>
-    <rule ref="PSR12.Operators.OperatorSpacing"/>
+    <rule ref="PSR12"/>
 
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 170 sniffs
+The SprykerStrict standard contains 171 sniffs
 
 Generic (23 sniffs)
 -------------------
@@ -42,9 +42,10 @@ PSR1 (3 sniffs)
 - PSR1.Files.SideEffects
 - PSR1.Methods.CamelCapsMethodName
 
-PSR12 (4 sniffs)
+PSR12 (5 sniffs)
 ----------------
 - PSR12.Classes.ClassInstantiation
+- PSR12.Functions.NullableTypeDeclaration
 - PSR12.Keywords.ShortFormTypeKeywords
 - PSR12.Namespaces.CompoundNamespaceDepth
 - PSR12.Operators.OperatorSpacing


### PR DESCRIPTION
```php
    /**
     * {@inheritdoc}
     *
     * @api
     *
     * @param null|string $application
     * @param null|string $store
     * @param null|string $environment
     *
     * @return void
     */
    public function setApplicationName(?string $application = null, ?string $store = null, ?string $environment = null): void
    {
        $this->getFactory()->createMonitoring()->setApplicationName($application, $store, $environment);
    }
```
didnt get fixed.

Now those are, too.