### PR TITLE
Fix support for union type arrays.

### DIFF
--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -314,6 +314,12 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     }
 
     /**
+     * Parses types respecting | union and () grouping.
+     *
+     * E.g.: `(string|int)[]|\ArrayObject` is parsed as `(string|int)[]` and `\ArrayObject`.
+     *
+     * The replace map trick is easier than a regex when keeping the () grouping per type.
+     *
      * @param string $content
      *
      * @return string[]


### PR DESCRIPTION
Resolves https://github.com/spryker/code-sniffer/issues/186

We need this as current workaround of `string[]|int[]` means sth different than `(string|int)[]`.
The latter is for mixed type inside a stack, whereas the first means same type per stack.
