### PR TITLE
TE-4490: fixed license file finder

### DIFF
--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -188,6 +188,20 @@ class FileDocBlockSniff extends AbstractFileDocBlockSniff
 
             return $this->getLicense($path) ?: null;
         }
+
+        if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'spryker' . DIRECTORY_SEPARATOR . 'spryker-shop' . DIRECTORY_SEPARATOR) === 0) {
+            $pathArray = explode(DIRECTORY_SEPARATOR, substr($path, 8));
+            array_shift($pathArray);
+            array_shift($pathArray);
+            array_shift($pathArray);
+
+            $path = getcwd() . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR
+                . 'spryker' . DIRECTORY_SEPARATOR . 'spryker-shop' . DIRECTORY_SEPARATOR
+                . 'Bundles' . DIRECTORY_SEPARATOR . array_shift($pathArray) . DIRECTORY_SEPARATOR;
+
+            return $this->getLicense($path) ?: null;
+        }
+
         if (strpos($path, DIRECTORY_SEPARATOR . 'Bundles' . DIRECTORY_SEPARATOR) === 0) {
             $pathArray = explode(DIRECTORY_SEPARATOR, substr($path, 8));
             array_shift($pathArray);


### PR DESCRIPTION
- Developer(s): @asmarovydlo

- Ticket: https://spryker.atlassian.net/browse/TE-4490

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/2088


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CodeSniffer           | patch (currently 0.x) {skip} |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module CodeSniffer

##### Change log

Initial Release

Bugfixes

- Adjusted `FileDocBlockSniff::findCustomLicense()` so now it's load `spryker-shop` modules license files properly.

