### PR TITLE
Allow basic generic<x, y> usage now.

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -59,7 +59,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
             }
-            if (!in_array($tokens[$i]['content'], ['@param'], true)) {
+            if ($tokens[$i]['content'] !== '@param') {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -132,7 +132,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
         $result = [];
 
         foreach ($classNames as $key => $className) {
-            if (strpos($className, 'array<') === 0) {
+            if (strpos($className, 'array<') === 0 || strpos($className, 'iterable<') === 0) {
                 // We skip for now
                 continue;
             }

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -69,11 +69,17 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
 
             $content = $tokens[$classNameIndex]['content'];
 
-            $appendix = '';
-            $spaceIndex = strpos($content, ' ');
-            if ($spaceIndex) {
-                $appendix = substr($content, $spaceIndex);
-                $content = substr($content, 0, $spaceIndex);
+            preg_match('#(.+<[^>]+>)#', $content, $matches);
+            if ($matches) {
+                $appendix = substr($content, strlen($matches[1]));
+                $content = $matches[1];
+            } else {
+                $appendix = '';
+                $spaceIndex = strpos($content, ' ');
+                if ($spaceIndex) {
+                    $appendix = substr($content, $spaceIndex);
+                    $content = substr($content, 0, $spaceIndex);
+                }
             }
 
             if (!$content) {
@@ -126,6 +132,11 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
         $result = [];
 
         foreach ($classNames as $key => $className) {
+            if (strpos($className, 'array<') === 0) {
+                // We skip for now
+                continue;
+            }
+
             $arrayOfObject = 0;
             while (substr($className, -2) === '[]') {
                 $arrayOfObject++;

--- a/Spryker/Tools/Traits/CommentingTrait.php
+++ b/Spryker/Tools/Traits/CommentingTrait.php
@@ -59,7 +59,7 @@ trait CommentingTrait
     protected function containsTypeArray(array $docBlockTypes): bool
     {
         foreach ($docBlockTypes as $docBlockType) {
-            if (strpos($docBlockType, '[]') !== false) {
+            if (strpos($docBlockType, '[]') !== false || strpos($docBlockType, 'array<') === 0) {
                 return true;
             }
         }


### PR DESCRIPTION
As first step this enables us to use and allow

    array<keytype, valuetype>
 
and

    iterable<type>

and similar scalar ones.