### PR TITLE
Fix docblock type issues and ref op spacing.

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -12,6 +12,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 /**
  * Verifies that a `@return` tag description does not start with $ sign to avoid accidental variable copy-and-paste.
+ * Also checks duplicates.
  *
  * @author Mark Scherer
  * @license MIT
@@ -31,15 +32,8 @@ class DocBlockReturnTagSniff extends AbstractSprykerSniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $this->assertDescription($phpcsFile, $stackPtr);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function assertDescription(File $phpcsFile, $stackPtr): void
-    {
         $tokens = $phpcsFile->getTokens();
+
         if ($tokens[$stackPtr]['content'] !== '@return') {
             return;
         }
@@ -48,6 +42,43 @@ class DocBlockReturnTagSniff extends AbstractSprykerSniff
         if (!$nextIndex) {
             return;
         }
+
+        $this->assertTypes($phpcsFile, $nextIndex);
+        $this->assertDescription($phpcsFile, $nextIndex);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $nextIndex
+     *
+     * @return void
+     */
+    protected function assertTypes(File $phpcsFile, int $nextIndex): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $content = $tokens[$nextIndex]['content'];
+        $returnTypes = explode('|', $content);
+
+        $unique = array_unique($returnTypes);
+        if (count($unique) !== count($returnTypes)) {
+            $after = implode('|', $unique);
+            $fix = $phpcsFile->addFixableError(sprintf('Types are duplicate: `%s`, expected `%s`.', $content, $after), $nextIndex, 'DuplicateTypes');
+            if ($fix) {
+                $phpcsFile->fixer->replaceToken($nextIndex, $after);
+            }
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param $nextIndex
+     *
+     * @return void
+     */
+    protected function assertDescription(File $phpcsFile, $nextIndex): void
+    {
+        $tokens = $phpcsFile->getTokens();
 
         $content = $tokens[$nextIndex]['content'];
         if (strpos($content, ' ') === false) {

--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -72,11 +72,11 @@ class DocBlockReturnTagSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param $nextIndex
+     * @param int $nextIndex
      *
      * @return void
      */
-    protected function assertDescription(File $phpcsFile, $nextIndex): void
+    protected function assertDescription(File $phpcsFile, int $nextIndex): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -71,15 +71,10 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     protected function assertOrder(File $phpCsFile, array $docBlockParams): void
     {
         foreach ($docBlockParams as $docBlockParam) {
-            if (strpos($docBlockParam['type'], '$') !== false) {
-                continue;
-            }
-
             $docBlockParamTypes = explode('|', $docBlockParam['type']);
             if (count($docBlockParamTypes) === 1) {
                 continue;
             }
-
             $unique = array_unique($docBlockParamTypes);
             if (count($docBlockParamTypes) !== count($unique)) {
                 $phpCsFile->addError('Duplicate type in `' . $docBlockParam['type'] . '`', $docBlockParam['index'], 'Duplicate');

--- a/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -75,7 +75,7 @@ class OperatorSpacingSniff extends AbstractSprykerSniff
         if ($tokens[$stackPtr]['code'] === T_BITWISE_AND) {
             // If its not a reference, then we expect one space either side of the
             // bitwise operator.
-            if (!$phpcsFile->isReference($stackPtr) ) {
+            if (!$phpcsFile->isReference($stackPtr)) {
                 // Check there is one space before the & operator.
                 if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
                     $error = 'Expected 1 space before "&" operator; 0 found';

--- a/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -75,7 +75,7 @@ class OperatorSpacingSniff extends AbstractSprykerSniff
         if ($tokens[$stackPtr]['code'] === T_BITWISE_AND) {
             // If its not a reference, then we expect one space either side of the
             // bitwise operator.
-            if ($phpcsFile->isReference($stackPtr) === false) {
+            if (!$phpcsFile->isReference($stackPtr) ) {
                 // Check there is one space before the & operator.
                 if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
                     $error = 'Expected 1 space before "&" operator; 0 found';
@@ -91,6 +91,14 @@ class OperatorSpacingSniff extends AbstractSprykerSniff
                     $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterAmp');
                     if ($fix) {
                         $phpcsFile->fixer->addContent($stackPtr, ' ');
+                    }
+                }
+            } else {
+                if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                    $error = 'Expected 0 spaces after reference operator';
+                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterReference');
+                    if ($fix) {
+                        $phpcsFile->fixer->replaceToken($stackPtr + 1, '');
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/spryker/code-sniffer/issues/224 and 
- stricter $this check
- param/return type check for unique
- ref op spacing
