### PR TITLE
Add Exit and DisallowFunctions sniff.

### DIFF
--- a/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Do not use functions that are problematic or not safe for upgrading.
+ */
+class DisallowFunctionsSniff implements Sniff
+{
+    /**
+     * @var string[]
+     */
+    public static $disallowed = [
+        'is_resource' => 'Not compatible with PHP 8+',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [T_STRING];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $this->checkForbiddenFunctions($phpcsFile, $stackPtr);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return void
+     */
+    protected function checkForbiddenFunctions(File $phpcsFile, int $stackPtr): void
+    {
+        $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
+
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenContent = $tokens[$stackPtr]['content'];
+        $key = strtolower($tokenContent);
+        if (!isset(static::$disallowed[$key])) {
+            return;
+        }
+
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
+            return;
+        }
+
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
+            return;
+        }
+
+        $error = 'Function ' . $tokenContent . '() usage found: ' . static::$disallowed[$key] . '.';
+        $phpcsFile->addError($error, $stackPtr, 'LongInvalid');
+    }
+}

--- a/Spryker/Sniffs/PHP/ExitSniff.php
+++ b/Spryker/Sniffs/PHP/ExitSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * Do not use functions that are problematic or not safe for upgrading.
+ * Do not use exit functions without argument. Check aliasing.
  */
 class ExitSniff implements Sniff
 {

--- a/Spryker/Sniffs/PHP/ExitSniff.php
+++ b/Spryker/Sniffs/PHP/ExitSniff.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Do not use functions that are problematic or not safe for upgrading.
+ */
+class ExitSniff implements Sniff
+{
+    /**
+     * @see http://php.net/manual/en/aliases.php
+     *
+     * @var string[]
+     */
+    public static $aliases = [
+        'die' => 'exit',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [T_EXIT];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $this->checkExitUsage($phpcsFile, $stackPtr);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return void
+     */
+    protected function checkExitUsage(File $phpcsFile, int $stackPtr): void
+    {
+        $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
+
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenContent = $tokens[$stackPtr]['content'];
+        $key = strtolower($tokenContent);
+        if (isset(static::$aliases[$key])) {
+            $this->fixAlias($phpcsFile, $stackPtr, $key);
+        }
+
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
+            return;
+        }
+
+        if ($tokens[$openingBrace]['parenthesis_closer'] > $openingBrace + 1) {
+            return;
+        }
+
+        $error = $key . '() without integer exit code argument is not allowed.';
+        $phpcsFile->addError($error, $stackPtr, 'Invalid');
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     * @param string $before
+     *
+     * @return void
+     */
+    protected function fixAlias(File $phpcsFile, int $stackPtr, string $before): void
+    {
+        $after = static::$aliases[$before];
+        $fix = $phpcsFile->addFixableError($before . '() should be ' . $after . '()', $stackPtr, 'Alias');
+        if (!$fix) {
+            return;
+        }
+
+        $phpcsFile->fixer->replaceToken($stackPtr, $after);
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 193 sniffs
+The SprykerStrict standard contains 195 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -102,7 +102,7 @@ SlevomatCodingStandard (24 sniffs)
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Spryker (83 sniffs)
+Spryker (85 sniffs)
 -------------------
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
@@ -167,6 +167,8 @@ Spryker (83 sniffs)
 - Spryker.Namespaces.SprykerNoPyz
 - Spryker.Namespaces.UseStatement
 - Spryker.Namespaces.UseWithAliasing
+- Spryker.PHP.DisallowFunctions
+- Spryker.PHP.Exit
 - Spryker.PHP.NoIsNull
 - Spryker.PHP.NotEqual
 - Spryker.PHP.PhpSapiConstant


### PR DESCRIPTION
Turns out the existing die()/exit() sniff didnt work as those tokens are not of type string, but T_EXIT
This is now fixed.

- die() to exit()
- exit() without integer argument is disallowed and treated as left-over accident from dev
- is_resource() is disallowed as it will always return false in PHP8

Resolves https://github.com/spryker/code-sniffer/pull/228