### PR TITLE
StrictCall sniff for level 2

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -281,7 +281,7 @@ abstract class AbstractSprykerSniff implements Sniff
 
                 continue;
             }
-            if (in_array($tokens[$i]['code'], $whitelistedCodes)) {
+            if (in_array($tokens[$i]['code'], $whitelistedCodes, true)) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
@@ -88,7 +88,7 @@ class DocBlockParamArraySniff extends AbstractSprykerSniff
                 continue;
             }
 
-            $keys = array_keys($parts, $detectedType);
+            $keys = array_keys($parts, $detectedType, true);
             foreach ($keys as $key) {
                 unset($parts[$key]);
             }

--- a/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
@@ -35,7 +35,7 @@ class ConditionalExpressionOrderSniff implements Sniff
         $tokens = $phpCsFile->getTokens();
 
         $prevIndex = $phpCsFile->findPrevious(Tokens::$emptyTokens, ($stackPointer - 1), null, true);
-        if (!in_array($tokens[$prevIndex]['code'], [T_TRUE, T_FALSE, T_NULL, T_LNUMBER, T_CONSTANT_ENCAPSED_STRING])) {
+        if (!in_array($tokens[$prevIndex]['code'], [T_TRUE, T_FALSE, T_NULL, T_LNUMBER, T_CONSTANT_ENCAPSED_STRING], true)) {
             return;
         }
 

--- a/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
@@ -59,7 +59,7 @@ class DisallowFunctionsSniff implements Sniff
         }
 
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens)) {
+        if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens, true)) {
             return;
         }
 
@@ -89,7 +89,7 @@ class DisallowFunctionsSniff implements Sniff
         }
 
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens)) {
+        if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens, true)) {
             return;
         }
 

--- a/Spryker/Sniffs/PHP/NoIsNullSniff.php
+++ b/Spryker/Sniffs/PHP/NoIsNullSniff.php
@@ -39,7 +39,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
         }
 
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
+        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens, true)) {
             return;
         }
 
@@ -162,7 +162,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
         if ($this->isCast($previous)) {
             return true;
         }
-        if (in_array($tokens[$previous]['code'], Tokens::$arithmeticTokens)) {
+        if (in_array($tokens[$previous]['code'], Tokens::$arithmeticTokens, true)) {
             return true;
         }
 
@@ -176,7 +176,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
      */
     protected function isCast(int $index): bool
     {
-        return in_array($index, Tokens::$castTokens);
+        return in_array($index, Tokens::$castTokens, true);
     }
 
     /**
@@ -190,12 +190,12 @@ class NoIsNullSniff extends AbstractSprykerSniff
         $tokens = $phpcsFile->getTokens();
 
         $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($index - 1), null, true);
-        if (!$previous || !in_array($tokens[$previous]['code'], [T_IS_IDENTICAL, T_IS_NOT_IDENTICAL])) {
+        if (!$previous || !in_array($tokens[$previous]['code'], [T_IS_IDENTICAL, T_IS_NOT_IDENTICAL], true)) {
             return null;
         }
 
         $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($previous - 1), null, true);
-        if (!$previous || !in_array($tokens[$previous]['code'], [T_TRUE, T_FALSE])) {
+        if (!$previous || !in_array($tokens[$previous]['code'], [T_TRUE, T_FALSE], true)) {
             return null;
         }
 
@@ -213,12 +213,12 @@ class NoIsNullSniff extends AbstractSprykerSniff
         $tokens = $phpcsFile->getTokens();
 
         $next = (int)$phpcsFile->findNext(T_WHITESPACE, ($index + 1), null, true);
-        if (!$next || !in_array($tokens[$next]['code'], [T_IS_IDENTICAL, T_IS_NOT_IDENTICAL])) {
+        if (!$next || !in_array($tokens[$next]['code'], [T_IS_IDENTICAL, T_IS_NOT_IDENTICAL], true)) {
             return null;
         }
 
         $next = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($next - 1), null, true);
-        if (!$next || !in_array($tokens[$next]['code'], [T_TRUE, T_FALSE])) {
+        if (!$next || !in_array($tokens[$next]['code'], [T_TRUE, T_FALSE], true)) {
             return null;
         }
 

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -43,7 +43,7 @@ class PhpSapiConstantSniff implements Sniff
         }
 
         $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
+        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens, true)) {
             return;
         }
 

--- a/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
+++ b/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
@@ -49,7 +49,7 @@ class PreferCastOverFunctionSniff extends AbstractSprykerSniff
         }
 
         $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
+        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens, true)) {
             return;
         }
 

--- a/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -72,7 +72,7 @@ class RemoveFunctionAliasSniff implements Sniff
         }
 
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
+        if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens, true)) {
             return;
         }
 

--- a/Spryker/Tools/Tokenizer.php
+++ b/Spryker/Tools/Tokenizer.php
@@ -54,7 +54,7 @@ class Tokenizer
 
         $this->root = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
         $this->path = $file;
-        $this->verbose = !empty($argv[2]) && in_array($argv[2], ['--verbose', '-v']);
+        $this->verbose = !empty($argv[2]) && in_array($argv[2], ['--verbose', '-v'], true);
     }
 
     /**

--- a/SprykerStrict/Sniffs/Functions/StrictCallSniff.php
+++ b/SprykerStrict/Sniffs/Functions/StrictCallSniff.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types = 1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerStrict\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use SlevomatCodingStandard\Helpers\ClassHelper;
+use SlevomatCodingStandard\Helpers\EmptyFileException;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use SlevomatCodingStandard\Sniffs\Functions\StrictCallSniff as SlevomatStrictCallSniff;
+
+/**
+ * Makes sure, that certain methods with type unsafe params are handled in strict mode.
+ * in_array(), array_keys(), array_search(), base64_decode() etc
+ */
+class StrictCallSniff extends SlevomatStrictCallSniff
+{
+    /**
+     * If not defined, will only be enabled for core level.
+     *
+     * @var bool|null
+     */
+    public $enable;
+
+    /**
+     * @var string
+     */
+    protected const NAMESPACE_SPRYKER = 'Spryker';
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stringPointer): void
+    {
+        $this->enable = $this->enable ?? $this->isCore($phpcsFile);
+
+        if (!$this->enable) {
+            return;
+        }
+
+        parent::process($phpcsFile, $stringPointer);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     *
+     * @return bool
+     */
+    protected function isCore(File $phpCsFile): bool
+    {
+        $namespace = $this->getNamespace($phpCsFile);
+
+        return strpos($namespace, static::NAMESPACE_SPRYKER) === 0;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     *
+     * @return string
+     */
+    protected function getNamespace(File $phpCsFile): string
+    {
+        $className = $this->getClassNameWithNamespace($phpCsFile);
+        if (!$className) {
+            return '';
+        }
+
+        $classNameParts = explode('\\', ltrim($className, '\\'));
+
+        return $classNameParts[0];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     *
+     * @return string|null
+     */
+    protected function getClassNameWithNamespace(File $phpCsFile): ?string
+    {
+        try {
+            $lastToken = TokenHelper::getLastTokenPointer($phpCsFile);
+        } catch (EmptyFileException $e) {
+            return null;
+        }
+
+        if (!NamespaceHelper::findCurrentNamespaceName($phpCsFile, $lastToken)) {
+            return null;
+        }
+
+        $prevIndex = $phpCsFile->findPrevious(TokenHelper::$typeKeywordTokenCodes, $lastToken);
+        if (!$prevIndex) {
+            return null;
+        }
+
+        return ClassHelper::getFullyQualifiedName(
+            $phpCsFile,
+            $prevIndex,
+        );
+    }
+}


### PR DESCRIPTION
RFC

> in_array(), array_keys(), array_search(), base64_decode()

for level 2 (strict level) only.

Example:
```php
$array = array(
    'egg' => true,
    'cheese' => false,
    'hair' => 765,
    'goblins' => null,
    'ogres' => 'no ogres allowed in this array'
);

// Invalid now: First three make sense, last four do not
in_array(null, $array); // true
in_array(false, $array); // true
in_array(765, $array); // true
in_array(763, $array); // true
in_array('egg', $array); // true
in_array('hhh', $array); // true
in_array(array(), $array); // true

// Valid:
in_array(null, $array, true); // true
in_array(false, $array, true); // true
in_array(765, $array, true); // true
in_array(763, $array, true); // false
in_array('egg', $array, true); // false
in_array('hhh', $array, true); // false
in_array(array(), $array, true); // false
```

