### PR TITLE
Remove deprecated sniff, update signature

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
@@ -202,11 +202,11 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      *
-     * @return int
+     * @return bool
      */
-    protected function isFileInPluginDirectory(File $phpCsFile): int
+    protected function isFileInPluginDirectory(File $phpCsFile): bool
     {
-        return preg_match('/Communication\/Plugin/', $phpCsFile->getFilename());
+        return (bool)preg_match('/Communication\/Plugin/', $phpCsFile->getFilename());
     }
 
     /**

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -50,7 +50,6 @@
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
 
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
 
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 195 sniffs
+The SprykerStrict standard contains 196 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -75,12 +75,12 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (24 sniffs)
+SlevomatCodingStandard (25 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
+- SlevomatCodingStandard.Classes.ClassMemberSpacing
 - SlevomatCodingStandard.Classes.ModernClassNameReference
-- SlevomatCodingStandard.Classes.UnusedPrivateElements
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment
 - SlevomatCodingStandard.Commenting.EmptyComment
 - SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch
@@ -93,6 +93,7 @@ SlevomatCodingStandard (24 sniffs)
 - SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash
 - SlevomatCodingStandard.Namespaces.UseFromSameNamespace
 - SlevomatCodingStandard.Namespaces.UseSpacing
+- SlevomatCodingStandard.PHP.ForbiddenClasses
 - SlevomatCodingStandard.PHP.ShortList
 - SlevomatCodingStandard.PHP.TypeCast
 - SlevomatCodingStandard.PHP.UselessSemicolon


### PR DESCRIPTION
SlevomatCodingStandard.Classes.UnusedPrivateElements is deprecated.