### PR TITLE
TE-8545: Fix double typo exception in Specification tag

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -350,7 +350,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         $fix = $phpCsFile->addFixableError('Typo in Specification tag.', $stackPointer, 'SpecificationTypo');
         if ($fix) {
             $phpCsFile->fixer->beginChangeset();
-            $phpCsFile->fixer->replaceToken($stackPointer, sprintf('%s:', $tokenContent));
+            $phpCsFile->fixer->replaceToken($stackPointer, sprintf('%s:', static::SPECIFICATION_TAG));
             $phpCsFile->fixer->endChangeset();
         }
     }


### PR DESCRIPTION
## PR Description

Ticket: [TE-8545](https://spryker.atlassian.net/browse/TE-8545)

This will try to fix any typos in Specification tag. 
One of common examples are:

```
/**
     * Specifications:
     * - Executed before adding item to cart.
     *
     * @api
```
```
/**
     * Specification::
     * - Executed before adding item to cart.
     *
     * @api
```
```
/**
     * Specifications::
     * - Executed before adding item to cart.
     *
     * @api
```
If the `Specification` part of tag is missing or the word is unidentifiable - "Missing Specification tag" error will be reported. In other cases - "Typo in Specification tag" fixable error. 