### PR TITLE
Methods marked as final can't be private in PHP 8+

### DIFF
--- a/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
+++ b/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
@@ -121,8 +121,8 @@ class MethodDeclarationSniff extends AbstractScopeSniff
         }
 
         if ($visibility && $final) {
-            if ($tokens[$visibility]['content'] !== 'public') {
-                $error = 'The final declaration requires public visibility for PHP 8+';
+            if ($tokens[$visibility]['content'] === 'private') {
+                $error = 'Methods marked as final can\'t be private in PHP 8+';
                 $phpcsFile->addError($error, $static, 'FinalVisibility');
             }
         }


### PR DESCRIPTION
## PR Description

Fixes the problem reported in https://github.com/spryker/code-sniffer/issues/241#issuecomment-814062652

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
