### PR TITLE
TE-8981 slevomat v7 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,4 @@ trim_trailing_whitespace = true
 end_of_line = crlf
 
 [*.yml]
-indent_style = space
 indent_size = 2

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
@@ -159,7 +159,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     {
         $tokens = $phpCsFile->getTokens();
 
-        $docBlockStartIndex = DocCommentHelper::findDocCommentOpenToken($phpCsFile, $stackPointer);
+        $docBlockStartIndex = DocCommentHelper::findDocCommentOpenPointer($phpCsFile, $stackPointer);
         $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
 
         for ($i = $docBlockEndIndex; $i >= $docBlockStartIndex; $i--) {

--- a/Spryker/Sniffs/Commenting/DocBlockTagIterableSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagIterableSniff.php
@@ -111,7 +111,7 @@ class DocBlockTagIterableSniff implements Sniff
      */
     protected function assertDefinition(string $definition): string
     {
-        return preg_replace_callback('#,([^ ])#', function ($matches) {
+        return (string)preg_replace_callback('#,([^ ])#', function ($matches) {
             return ', ' . $matches[1];
         }, $definition);
     }

--- a/Spryker/Sniffs/Testing/MockSniff.php
+++ b/Spryker/Sniffs/Testing/MockSniff.php
@@ -9,7 +9,6 @@ namespace Spryker\Sniffs\Testing;
 
 use PHP_CodeSniffer\Files\File;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
-use SlevomatCodingStandard\Helpers\ReturnTypeHint;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 /**
@@ -49,7 +48,7 @@ class MockSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
-     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|null $returnTypeHint
+     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|\SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
      * @param string[] $docBlockReturnTypes
      *
      * @return void
@@ -57,7 +56,7 @@ class MockSniff extends AbstractSprykerSniff
     protected function assertNoReturnTypehint(
         File $phpcsFile,
         int $stackPtr,
-        ?ReturnTypeHint $returnTypeHint,
+        $returnTypeHint,
         array $docBlockReturnTypes
     ): void {
         if (!$returnTypeHint || $returnTypeHint->getTypeHint() !== 'MockObject') {
@@ -75,11 +74,11 @@ class MockSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
-     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint $returnTypeHint
+     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|\SlevomatCodingStandard\Helpers\TypeHint $returnTypeHint
      *
      * @return void
      */
-    protected function removeReturnTypeHint(File $phpcsFile, int $stackPtr, ReturnTypeHint $returnTypeHint): void
+    protected function removeReturnTypeHint(File $phpcsFile, int $stackPtr, $returnTypeHint): void
     {
         $colonPointer = $phpcsFile->findPrevious(T_COLON, $returnTypeHint->getStartPointer(), $stackPtr);
         if (!$colonPointer) {
@@ -100,7 +99,7 @@ class MockSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
      * @param string[] $docBlockReturnTypes
-     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|null $returnTypeHint
+     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|\SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
      *
      * @return void
      */
@@ -108,7 +107,7 @@ class MockSniff extends AbstractSprykerSniff
         File $phpcsFile,
         int $stackPtr,
         array $docBlockReturnTypes,
-        ?ReturnTypeHint $returnTypeHint
+        $returnTypeHint
     ): void {
         $hasMockAnnotation = $this->hasMockObjectAnnotation($docBlockReturnTypes);
 

--- a/Spryker/Sniffs/Testing/MockSniff.php
+++ b/Spryker/Sniffs/Testing/MockSniff.php
@@ -9,6 +9,7 @@ namespace Spryker\Sniffs\Testing;
 
 use PHP_CodeSniffer\Files\File;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
+use SlevomatCodingStandard\Helpers\TypeHint;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 /**
@@ -48,7 +49,7 @@ class MockSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
-     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|\SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
+     * @param \SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
      * @param string[] $docBlockReturnTypes
      *
      * @return void
@@ -56,7 +57,7 @@ class MockSniff extends AbstractSprykerSniff
     protected function assertNoReturnTypehint(
         File $phpcsFile,
         int $stackPtr,
-        $returnTypeHint,
+        ?TypeHint $returnTypeHint,
         array $docBlockReturnTypes
     ): void {
         if (!$returnTypeHint || $returnTypeHint->getTypeHint() !== 'MockObject') {
@@ -74,11 +75,11 @@ class MockSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
-     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|\SlevomatCodingStandard\Helpers\TypeHint $returnTypeHint
+     * @param \SlevomatCodingStandard\Helpers\TypeHint $returnTypeHint
      *
      * @return void
      */
-    protected function removeReturnTypeHint(File $phpcsFile, int $stackPtr, $returnTypeHint): void
+    protected function removeReturnTypeHint(File $phpcsFile, int $stackPtr, TypeHint $returnTypeHint): void
     {
         $colonPointer = $phpcsFile->findPrevious(T_COLON, $returnTypeHint->getStartPointer(), $stackPtr);
         if (!$colonPointer) {
@@ -99,7 +100,7 @@ class MockSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
      * @param string[] $docBlockReturnTypes
-     * @param \SlevomatCodingStandard\Helpers\ReturnTypeHint|\SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
+     * @param \SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
      *
      * @return void
      */
@@ -107,7 +108,7 @@ class MockSniff extends AbstractSprykerSniff
         File $phpcsFile,
         int $stackPtr,
         array $docBlockReturnTypes,
-        $returnTypeHint
+        ?TypeHint $returnTypeHint
     ): void {
         $hasMockAnnotation = $this->hasMockObjectAnnotation($docBlockReturnTypes);
 

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -177,4 +177,9 @@
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 
+    <!-- Disallow PHP8 specific behavior until code is PHP8+ only -->
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
+
 </ruleset>

--- a/SprykerStrict/Sniffs/TypeHints/ReturnTypeHintSniff.php
+++ b/SprykerStrict/Sniffs/TypeHints/ReturnTypeHintSniff.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerStrict\Sniffs\TypeHints;
+
+use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff as SlevomatReturnTypeHintSniff;
+
+class ReturnTypeHintSniff extends SlevomatReturnTypeHintSniff
+{
+}

--- a/SprykerStrict/ruleset.xml
+++ b/SprykerStrict/ruleset.xml
@@ -14,6 +14,9 @@
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.UselessAnnotation"/>
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.UselessDocComment"/>
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+        <properties>
+            <property name="enableNativeTypeHint" type="bool" value="false"/>
+        </properties>
     </rule>
     <rule ref="SprykerStrict.TypeHints.PropertyTypeHint">
         <exclude name="SprykerStrict.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>

--- a/SprykerStrict/ruleset.xml
+++ b/SprykerStrict/ruleset.xml
@@ -15,7 +15,18 @@
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.UselessDocComment"/>
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
         <properties>
-            <property name="enableNativeTypeHint" type="bool" value="false"/>
+            <property name="enableMixedTypeHint" type="bool" value="false"/>
+            <property name="enableUnionTypeHint" type="bool" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="SprykerStrict.TypeHints.ReturnTypeHint">
+        <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+        <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.UselessDocComment"/>
+        <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+        <properties>
+            <property name="enableMixedTypeHint" type="bool" value="false"/>
+            <property name="enableUnionTypeHint" type="bool" value="false"/>
         </properties>
     </rule>
     <rule ref="SprykerStrict.TypeHints.PropertyTypeHint">
@@ -25,6 +36,8 @@
         <exclude name="SprykerStrict.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
         <properties>
             <property name="enableNativeTypeHint" type="bool" value="false"/>
+            <property name="enableMixedTypeHint" type="bool" value="false"/>
+            <property name="enableUnionTypeHint" type="bool" value="false"/>
         </properties>
     </rule>
 

--- a/SprykerStrict/ruleset.xml
+++ b/SprykerStrict/ruleset.xml
@@ -25,6 +25,7 @@
         <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.UselessDocComment"/>
         <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
         <properties>
+            <property name="enableStaticTypeHint" type="bool" value="false"/>
             <property name="enableMixedTypeHint" type="bool" value="false"/>
             <property name="enableUnionTypeHint" type="bool" value="false"/>
         </properties>

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": ">=7.2",
     "squizlabs/php_codesniffer": "^3.5.5",
-    "slevomat/coding-standard": "^6.3.11"
+    "slevomat/coding-standard": "^6.3.11 || ^7.0.1"
   },
   "require-dev": {
     "dereuromark/composer-prefer-lowest": "^0.1.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "squizlabs/php_codesniffer": "^3.5.5",
+    "squizlabs/php_codesniffer": "^3.6.0",
     "slevomat/coding-standard": "^7.0.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": ">=7.2",
     "squizlabs/php_codesniffer": "^3.5.5",
-    "slevomat/coding-standard": "^6.3.11 || ^7.0.1"
+    "slevomat/coding-standard": "^7.0.1"
   },
   "require-dev": {
     "dereuromark/composer-prefer-lowest": "^0.1.2",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 197 sniffs
+The SprykerStrict standard contains 201 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -75,19 +75,22 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (25 sniffs)
+SlevomatCodingStandard (28 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
 - SlevomatCodingStandard.Classes.ClassMemberSpacing
+- SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion
 - SlevomatCodingStandard.Classes.ModernClassNameReference
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment
 - SlevomatCodingStandard.Commenting.EmptyComment
 - SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch
+- SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator
 - SlevomatCodingStandard.ControlStructures.DisallowYodaComparison
 - SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
 - SlevomatCodingStandard.ControlStructures.NewWithParentheses
 - SlevomatCodingStandard.Exceptions.DeadCatch
+- SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration
 - SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
 - SlevomatCodingStandard.Namespaces.UnusedUses
 - SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash
@@ -191,10 +194,11 @@ Spryker (85 sniffs)
 - Spryker.WhiteSpace.ObjectAttributeSpacing
 - Spryker.WhiteSpace.OperatorSpacing
 
-SprykerStrict (2 sniffs)
+SprykerStrict (3 sniffs)
 ------------------------
 - SprykerStrict.TypeHints.ParameterTypeHint
 - SprykerStrict.TypeHints.PropertyTypeHint
+- SprykerStrict.TypeHints.ReturnTypeHint
 
 Squiz (27 sniffs)
 -----------------


### PR DESCRIPTION
https://spryker.atlassian.net/browse/TE-8981

I first tried 6 || 7, but that didn't work out without quite some hacks

So now it is v7 only, which requires this to be a new minor release (semantic major).

That means:
- We disallow PHP8 only syntax until the library and the using project/core code is also PHP8+ only.

We can schedule this new "major" for end of April.