### PR TITLE
TE-9147 Add sniff for exceptException calls

### DIFF
--- a/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
+++ b/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\Testing;
+
+use PHP_CodeSniffer\Files\File;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+
+/**
+ * Ensures no assert*() usage after expectException() calls, as those are no-op.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class ExpectExceptionSniff extends AbstractSprykerSniff
+{
+    protected const METHOD_EXPECT_EXCEPTION = 'expectException';
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [T_FUNCTION];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (!$this->isTest($phpcsFile, $stackPtr)) {
+            return;
+        }
+
+        $this->assertNoAssertsAfterExpectException($phpcsFile, $stackPtr);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return void
+     */
+    protected function assertNoAssertsAfterExpectException(
+        File $phpcsFile,
+        int $stackPtr
+    ): void {
+        $tokens = $phpcsFile->getTokens();
+
+        $curlyBraceStartIndex = $tokens[$stackPtr]['scope_opener'];
+        $curlyBraceEndIndex = $tokens[$stackPtr]['scope_closer'];
+
+        for ($i = $curlyBraceStartIndex + 1; $i < $curlyBraceEndIndex; $i++) {
+            if ($tokens[$i]['code'] !== T_VARIABLE) {
+                continue;
+            }
+            if ($tokens[$i + 1]['code'] !== T_OBJECT_OPERATOR) {
+                continue;
+            }
+            if ($tokens[$i + 2]['code'] !== T_STRING) {
+                continue;
+            }
+
+            $tokenContent = $tokens[$i + 2]['content'];
+            $exceptionStrings = [
+                'expectException',
+                'expectExceptionObject',
+                'expectExceptionCode',
+                //TOOD more? *Message *MessageObject ?
+            ];
+            if (!in_array($tokenContent, $exceptionStrings, true)) {
+                continue;
+            }
+
+            $this->assertNoFollowingAsserts($phpcsFile, $i + 2, $curlyBraceEndIndex);
+
+            break;
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $expectationIndex
+     * @param int $endIndex
+     *
+     * @return void
+     */
+    protected function assertNoFollowingAsserts(File $phpcsFile, int $expectationIndex, int $endIndex): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $expectationIndex + 1; $i < $endIndex; $i++) {
+            if ($tokens[$i]['code'] !== T_VARIABLE) {
+                continue;
+            }
+            if ($tokens[$i + 1]['code'] !== T_OBJECT_OPERATOR) {
+                continue;
+            }
+            if ($tokens[$i + 2]['code'] !== T_STRING) {
+                continue;
+            }
+
+            $tokenContent = $tokens[$i + 2]['content'];
+            if (!preg_match('/assert[A-Z].+/', $tokenContent)) {
+                continue;
+            }
+
+            $phpcsFile->addError('expect*() call must not be followed by assert*() calls.', $i, 'InvalidAssert');
+
+            break;
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return bool
+     */
+    protected function isTest(File $phpcsFile, int $stackPtr): bool
+    {
+        $filename = $phpcsFile->getFilename();
+        if (substr($filename, -8) !== 'Test.php' && substr($filename, -9) !== 'Mocks.php') {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
+++ b/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
@@ -51,12 +51,15 @@ class ExpectExceptionSniff extends AbstractSprykerSniff
         int $stackPtr
     ): void {
         $tokens = $phpcsFile->getTokens();
+        if (empty($tokens[$stackPtr]['scope_opener'])) {
+            return;
+        }
 
         $curlyBraceStartIndex = $tokens[$stackPtr]['scope_opener'];
         $curlyBraceEndIndex = $tokens[$stackPtr]['scope_closer'];
 
         for ($i = $curlyBraceStartIndex + 1; $i < $curlyBraceEndIndex; $i++) {
-            if ($tokens[$i]['code'] !== T_VARIABLE) {
+            if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
                 continue;
             }
             if ($tokens[$i + 1]['code'] !== T_OBJECT_OPERATOR) {
@@ -95,7 +98,7 @@ class ExpectExceptionSniff extends AbstractSprykerSniff
         $tokens = $phpcsFile->getTokens();
 
         for ($i = $expectationIndex + 1; $i < $endIndex; $i++) {
-            if ($tokens[$i]['code'] !== T_VARIABLE) {
+            if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
                 continue;
             }
             if ($tokens[$i + 1]['code'] !== T_OBJECT_OPERATOR) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 201 sniffs
+The SprykerStrict standard contains 202 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -106,7 +106,7 @@ SlevomatCodingStandard (28 sniffs)
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Spryker (85 sniffs)
+Spryker (86 sniffs)
 -------------------
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
@@ -180,6 +180,7 @@ Spryker (85 sniffs)
 - Spryker.PHP.RemoveFunctionAlias
 - Spryker.PHP.ShortCast
 - Spryker.PHP.SingleQuote
+- Spryker.Testing.ExpectException
 - Spryker.Testing.Mock
 - Spryker.WhiteSpace.CommaSpacing
 - Spryker.WhiteSpace.ConcatenationSpacing


### PR DESCRIPTION
https://spryker.atlassian.net/browse/TE-9147

New `Spryker.Testing.ExpectException` goes into new major release this week.

requires our core branches to be fixed up first here before we can merge this.