### PR TITLE
TE-9414 Compatibility with PHP8 attributes.

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -281,10 +281,11 @@ abstract class AbstractSprykerSniff implements Sniff
     {
         $tokens = $phpCsFile->getTokens();
 
-        $line = $tokens[$stackPointer]['line'];
-        $beginningOfLine = $stackPointer;
-        while (!empty($tokens[$beginningOfLine - 1]) && $tokens[$beginningOfLine - 1]['line'] === $line) {
-            $beginningOfLine--;
+        $beginningOfLine = $this->getFirstTokenOfLine($tokens, $stackPointer);
+
+        $prevContentIndex = $phpCsFile->findPrevious(T_WHITESPACE, $beginningOfLine - 1, null, true);
+        if ($tokens[$prevContentIndex]['type'] === 'T_ATTRIBUTE_END') {
+            $beginningOfLine = $this->getFirstTokenOfLine($tokens, $prevContentIndex);
         }
 
         if (!empty($tokens[$beginningOfLine - 2]) && $tokens[$beginningOfLine - 2]['type'] === 'T_DOC_COMMENT_CLOSE_TAG') {
@@ -385,7 +386,7 @@ abstract class AbstractSprykerSniff implements Sniff
 
         $firstIndex = $this->getFirstTokenOfLine($tokens, $prevIndex);
         $whitespace = '';
-        if ($tokens[$firstIndex]['type'] === 'T_WHITESPACE') {
+        if ($tokens[$firstIndex]['type'] === 'T_WHITESPACE' || $tokens[$firstIndex]['type'] === 'T_DOC_COMMENT_WHITESPACE') {
             $whitespace = $tokens[$firstIndex]['content'];
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockSniff.php
@@ -63,7 +63,7 @@ class DocBlockSniff extends AbstractSprykerSniff
             return;
         }
 
-        $fix = $phpcsFile->addFixableError('Method does not have a return void statement in doc block: ' . $tokens[$nextIndex]['content'], $nextIndex, 'ReturnVoidMissing');
+        $fix = $phpcsFile->addFixableError('Method does not have a docblock with return void statement: ' . $tokens[$nextIndex]['content'], $nextIndex, 'ReturnVoidMissing');
         if (!$fix) {
             return;
         }
@@ -83,6 +83,11 @@ class DocBlockSniff extends AbstractSprykerSniff
         $tokens = $phpcsFile->getTokens();
 
         $firstTokenOfLine = $this->getFirstTokenOfLine($tokens, $index);
+
+        $prevContentIndex = $phpcsFile->findPrevious(T_WHITESPACE, $firstTokenOfLine - 1, null, true);
+        if ($tokens[$prevContentIndex]['type'] === 'T_ATTRIBUTE_END') {
+            $firstTokenOfLine = $this->getFirstTokenOfLine($tokens, $prevContentIndex);
+        }
 
         $indentation = $this->getIndentationWhitespace($phpcsFile, $index);
 

--- a/Spryker/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -8,13 +8,13 @@
 namespace Spryker\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 
 /**
  * There should always be newlines around functions/methods.
  */
-class FunctionSpacingSniff implements Sniff
+class FunctionSpacingSniff extends AbstractSprykerSniff
 {
     /**
      * @inheritDoc
@@ -115,13 +115,13 @@ class FunctionSpacingSniff implements Sniff
     {
         $tokens = $phpCsFile->getTokens();
 
-        $line = $tokens[$stackPointer]['line'];
-        $firstTokenInLineIndex = $stackPointer;
-        while ($tokens[$firstTokenInLineIndex - 1]['line'] === $line) {
-            $firstTokenInLineIndex--;
-        }
+        $firstTokenInLineIndex = $this->getFirstTokenOfLine($tokens, $stackPointer);
 
         $prevContentIndex = $phpCsFile->findPrevious(T_WHITESPACE, $firstTokenInLineIndex - 1, null, true);
+        if ($tokens[$prevContentIndex]['type'] === 'T_ATTRIBUTE_END') {
+            return;
+        }
+
         if ($tokens[$prevContentIndex]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
             $firstTokenInLineIndex = $tokens[$prevContentIndex]['comment_opener'];
             $line = $tokens[$firstTokenInLineIndex]['line'];


### PR DESCRIPTION
https://spryker.atlassian.net/browse/TE-9414

Fixed:
- docblock finding for class/method
- fixing of content inside such a docblock now works, including proper indentation detection.

The following snippet should now be fine:

```php
<?php

/**
 * MIT License
 * For full license information, please view the LICENSE file that was distributed with this source code.
 */

namespace Spryker;

/**
 * Class Test
 */
#[Attribute]
class Test
{
    /**
     * Some sentence.
     *
     * @param int $param Some Param.
     * @param bool $otherParam Some Other Param.
     *
     * @return void
     */
    #[ReturnTypeWillChange]
    public function returnWillChange(int $param, bool $otherParam): void
    {
    }
}
```