### PR TITLE
Fix whitespace around short ternary.

### DIFF
--- a/Spryker/Sniffs/WhiteSpace/TernarySpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/TernarySpacingSniff.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+
+/**
+ * Verifies that short ternary operators have valid spacing surrounding them.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class TernarySpacingSniff extends AbstractSprykerSniff
+{
+    /**
+     * @var string[]
+     */
+    public $supportedTokenizers = [
+        'PHP',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [
+            T_INLINE_THEN,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        if (!$nextIndex || $nextIndex - 1 === $stackPtr || $tokens[$nextIndex]['code'] !== T_INLINE_ELSE) {
+            return;
+        }
+
+        if ($tokens[$nextIndex - 1]['code'] !== T_WHITESPACE) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError('Additional whitespace found between short ternary', $stackPtr, 'InvalidWhitespace');
+        if (!$fix) {
+            return;
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->replaceToken($nextIndex - 1, '');
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 204 sniffs
+The SprykerStrict standard contains 205 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -107,7 +107,7 @@ SlevomatCodingStandard (29 sniffs)
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Spryker (87 sniffs)
+Spryker (88 sniffs)
 -------------------
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
@@ -196,6 +196,7 @@ Spryker (87 sniffs)
 - Spryker.WhiteSpace.NamespaceSpacing
 - Spryker.WhiteSpace.ObjectAttributeSpacing
 - Spryker.WhiteSpace.OperatorSpacing
+- Spryker.WhiteSpace.TernarySpacing
 
 SprykerStrict (3 sniffs)
 ------------------------


### PR DESCRIPTION
https://spryker.atlassian.net/browse/TE-9691

    $x = $param ?    : null;

must be

    $x = $param ?: null;

As this was expected but missing, this is classified as fix.