### PR TITLE
TE-9806 Docblocks for const

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractApiClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractApiClassDetectionSprykerSniff.php
@@ -11,11 +11,29 @@ use PHP_CodeSniffer\Files\File;
 
 abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const API_FACADE = 'FACADE';
+    /**
+     * @var string
+     */
     protected const API_SERVICE = 'SERVICE';
+    /**
+     * @var string
+     */
     protected const API_CLIENT = 'CLIENT';
+    /**
+     * @var string
+     */
     protected const API_QUERY_CONTAINER = 'QUERY_CONTAINER';
+    /**
+     * @var string
+     */
     protected const API_PLUGIN = 'PLUGIN';
+    /**
+     * @var string
+     */
     protected const API_CONFIG = 'CONFIG';
 
     /**

--- a/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
@@ -12,10 +12,19 @@ use SlevomatCodingStandard\Helpers\DocCommentHelper;
 
 abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const LAYER_PERSISTENCE = 'Persistence';
 
+    /**
+     * @var string
+     */
     protected const LAYER_COMMUNICATION = 'Communication';
 
+    /**
+     * @var string
+     */
     protected const LAYER_BUSINESS = 'Business';
 
     /**

--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -21,6 +21,9 @@ abstract class AbstractSprykerSniff implements Sniff
 {
     use BasicsTrait;
 
+    /**
+     * @var string
+     */
     protected const NAMESPACE_SPRYKER = 'Spryker';
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -15,8 +15,14 @@ use Spryker\Sniffs\AbstractSniffs\AbstractApiClassDetectionSprykerSniff;
  */
 class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const INHERIT_DOC = '{@inheritDoc}';
 
+    /**
+     * @var string
+     */
     protected const SPECIFICATION_TAG = 'Specification';
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -251,7 +251,7 @@ class DocBlockConstSniff extends AbstractSprykerSniff
             return;
         }
 
-        $index = $phpCsFile->findPrevious(Tokens::$emptyTokens, $docBlockEndIndex - 1, $docBlockStartIndex, true);
+        $index = $phpCsFile->findPrevious(T_DOC_COMMENT_WHITESPACE, $docBlockEndIndex - 1, $docBlockStartIndex, true);
         if (!$index) {
             $index = $docBlockStartIndex;
         }

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -44,7 +44,8 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         if (!$docBlockEndIndex) {
             $defaultValueType = $this->findDefaultValueType($phpCsFile, $stackPointer);
             if ($defaultValueType === null) {
-                $phpCsFile->addError('Doc Block for const missing', $stackPointer, 'VarDocBlockMissing');
+                // Let's ignore for now
+                //$phpCsFile->addError('Doc Block for const missing', $stackPointer, 'VarDocBlockMissing');
 
                 return;
             }
@@ -229,14 +230,10 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         int $docBlockStartIndex,
         ?string $defaultValueType
     ): void {
-        // Let's skip for now for non-trivial cases
-        if ($defaultValueType === null) {
-            return;
-        }
-
         $error = 'Doc Block annotation @var for const missing';
         if ($defaultValueType === null) {
-            $phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockMissing');
+            // Let's skip for now for non-trivial cases
+            //$phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockMissing');
 
             return;
         }

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+use Spryker\Tools\Traits\CommentingTrait;
+
+/**
+ * Ensures Doc Blocks for constants exist and are correct.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class DocBlockConstSniff extends AbstractSprykerSniff
+{
+    use CommentingTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [
+            T_CONST,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpCsFile, $stackPointer)
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
+
+        if (!$docBlockEndIndex) {
+            $defaultValueType = $this->findDefaultValueType($phpCsFile, $stackPointer);
+            if ($defaultValueType === null) {
+                $phpCsFile->addError('Doc Block for const missing', $stackPointer, 'VarDocBlockMissing');
+
+                return;
+            }
+
+            $phpCsFile->addFixableError('Doc Block for const missing', $stackPointer, 'VarDocBlockMissing');
+            $this->addDocBlock($phpCsFile, $stackPointer, $defaultValueType);
+
+            return;
+        }
+
+        $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
+
+        $defaultValueType = $this->findDefaultValueType($phpCsFile, $stackPointer);
+
+        $varIndex = null;
+        for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
+            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+                continue;
+            }
+            if (!in_array($tokens[$i]['content'], ['@var'], true)) {
+                continue;
+            }
+
+            $varIndex = $i;
+        }
+
+        if (!$varIndex) {
+            $this->handleMissingVar($phpCsFile, $docBlockEndIndex, $docBlockStartIndex, $defaultValueType);
+
+            return;
+        }
+
+        $classNameIndex = $varIndex + 2;
+
+        if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
+            $this->handleMissingVarType($phpCsFile, $varIndex, $defaultValueType);
+
+            return;
+        }
+
+        $content = $tokens[$classNameIndex]['content'];
+
+        $appendix = '';
+        $spaceIndex = strpos($content, ' ');
+        if ($spaceIndex) {
+            $appendix = substr($content, $spaceIndex);
+            $content = substr($content, 0, $spaceIndex);
+        }
+
+        if (empty($content)) {
+            $error = 'Doc Block type for property annotation @var missing';
+            if ($defaultValueType) {
+                $error .= ', type `' . $defaultValueType . '` detected';
+            }
+            $phpCsFile->addError($error, $stackPointer, 'VarTypeEmpty');
+
+            return;
+        }
+
+        if ($defaultValueType === null) {
+            return;
+        }
+
+        $parts = explode('|', $content);
+        if (in_array($defaultValueType, $parts, true)) {
+            return;
+        }
+        if ($defaultValueType === 'array' && $this->containsTypeArray($parts)) {
+            return;
+        }
+        if ($defaultValueType === 'false' && in_array('bool', $parts, true)) {
+            return;
+        }
+
+        if ($defaultValueType === 'false') {
+            $defaultValueType = 'bool';
+        }
+
+        if (count($parts) > 1 || $defaultValueType === 'null') {
+            $fix = $phpCsFile->addFixableError('Doc Block type for property annotation @var incorrect, type `' . $defaultValueType . '` missing', $stackPointer, 'VarTypeMissing');
+            if ($fix) {
+                $phpCsFile->fixer->replaceToken($classNameIndex, implode('|', $parts) . '|' . $defaultValueType . $appendix);
+            }
+
+            return;
+        }
+
+        $fix = $phpCsFile->addFixableError('Doc Block type `' . $content . '` for property annotation @var incorrect, type `' . $defaultValueType . '` expected', $stackPointer, 'VarTypeIncorrect');
+        if ($fix) {
+            $phpCsFile->fixer->replaceToken($classNameIndex, $defaultValueType . $appendix);
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $stackPointer
+     *
+     * @return string|null
+     */
+    protected function findDefaultValueType(File $phpCsFile, int $stackPointer): ?string
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        $nameIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $stackPointer + 1, null, true);
+        if (!$nameIndex || !$this->isGivenKind(T_STRING, $tokens[$nameIndex])) {
+            return null;
+        }
+
+        $nextIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $nameIndex + 1, null, true);
+        if (!$nextIndex || !$this->isGivenKind(T_EQUAL, $tokens[$nextIndex])) {
+            return null;
+        }
+
+        $nextIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $nextIndex + 1, null, true);
+        if (!$nextIndex) {
+            return null;
+        }
+
+        return $this->detectType($tokens[$nextIndex]);
+    }
+
+    /**
+     * @param array $token
+     *
+     * @return string|null
+     */
+    protected function detectType(array $token): ?string
+    {
+        if ($this->isGivenKind(T_OPEN_SHORT_ARRAY, $token)) {
+            return 'array';
+        }
+
+        if ($this->isGivenKind(T_LNUMBER, $token)) {
+            return 'int';
+        }
+
+        if ($this->isGivenKind(T_CONSTANT_ENCAPSED_STRING, $token)) {
+            return 'string';
+        }
+
+        if ($this->isGivenKind([T_TRUE], $token)) {
+            return 'bool';
+        }
+
+        if ($this->isGivenKind([T_FALSE], $token)) {
+            return 'false';
+        }
+
+        if ($this->isGivenKind(T_NULL, $token)) {
+            return 'null';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $docBlockEndIndex
+     * @param int $docBlockStartIndex
+     * @param string|null $defaultValueType
+     *
+     * @return void
+     */
+    protected function handleMissingVar(
+        File $phpCsFile,
+        int $docBlockEndIndex,
+        int $docBlockStartIndex,
+        ?string $defaultValueType
+    ): void {
+        $error = 'Doc Block annotation @var for const missing';
+        if ($defaultValueType === null) {
+            $phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockMissing');
+
+            return;
+        }
+
+        if ($defaultValueType === 'false') {
+            $defaultValueType = 'bool';
+        }
+
+        $error .= ', type `' . $defaultValueType . '` detected';
+        $fix = $phpCsFile->addFixableError($error, $docBlockEndIndex, 'WrongType');
+        if (!$fix) {
+            return;
+        }
+
+        $index = $phpCsFile->findPrevious(Tokens::$emptyTokens, $docBlockEndIndex - 1, $docBlockStartIndex, true);
+        if (!$index) {
+            $index = $docBlockStartIndex;
+        }
+
+        $phpCsFile->fixer->beginChangeset();
+        $phpCsFile->fixer->addNewline($index);
+        $phpCsFile->fixer->addContent($index, "\t" . ' * @var ' . $defaultValueType);
+        $phpCsFile->fixer->endChangeset();
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $varIndex
+     * @param string|null $defaultValueType
+     *
+     * @return void
+     */
+    protected function handleMissingVarType(File $phpCsFile, int $varIndex, ?string $defaultValueType): void
+    {
+        $error = 'Doc Block type for property annotation @var missing';
+        if ($defaultValueType === null) {
+            $phpCsFile->addError($error, $varIndex, 'VarTypeMissing');
+
+            return;
+        }
+
+        if ($defaultValueType === 'false') {
+            $defaultValueType = 'bool';
+        }
+
+        $error .= ', type `' . $defaultValueType . '` detected';
+        $fix = $phpCsFile->addFixableError($error, $varIndex, 'WrongType');
+        if (!$fix) {
+            return;
+        }
+
+        $phpCsFile->fixer->beginChangeset();
+        $phpCsFile->fixer->addContent($varIndex, ' ' . $defaultValueType);
+        $phpCsFile->fixer->endChangeset();
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param int $stackPointer
+     * @param string $defaultValueType
+     *
+     * @return void
+     */
+    protected function addDocBlock(File $phpCsFile, int $stackPointer, string $defaultValueType): void
+    {
+        if ($defaultValueType === 'false') {
+            $defaultValueType = 'bool';
+        }
+
+        $tokens = $phpCsFile->getTokens();
+
+        $firstTokenOfLine = $this->getFirstTokenOfLine($tokens, $stackPointer);
+
+        $prevContentIndex = $phpCsFile->findPrevious(T_WHITESPACE, $firstTokenOfLine - 1, null, true);
+        if ($tokens[$prevContentIndex]['type'] === 'T_ATTRIBUTE_END') {
+            $firstTokenOfLine = $this->getFirstTokenOfLine($tokens, $prevContentIndex);
+        }
+
+        $indentation = $this->getIndentationWhitespace($phpCsFile, $stackPointer);
+
+        $phpCsFile->fixer->beginChangeset();
+        $phpCsFile->fixer->addNewlineBefore($firstTokenOfLine);
+        $phpCsFile->fixer->addContentBefore($firstTokenOfLine, $indentation . ' */');
+        $phpCsFile->fixer->addNewlineBefore($firstTokenOfLine);
+        $phpCsFile->fixer->addContentBefore($firstTokenOfLine, $indentation . ' * @var ' . $defaultValueType);
+        $phpCsFile->fixer->addNewlineBefore($firstTokenOfLine);
+        $phpCsFile->fixer->addContentBefore($firstTokenOfLine, $indentation . '/**');
+
+        $phpCsFile->fixer->endChangeset();
+    }
+}

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -43,15 +43,15 @@ class DocBlockConstSniff extends AbstractSprykerSniff
 
         if (!$docBlockEndIndex) {
             $defaultValueType = $this->findDefaultValueType($phpCsFile, $stackPointer);
-            if ($defaultValueType === 'null') {
-                $phpCsFile->addError('Doc Block `@var` with type `...|' . $defaultValueType . '` for const missing', $stackPointer, 'VarDocBlockMissing');
+            if ($defaultValueType === null) {
+                // Let's ignore for now
+                //$phpCsFile->addError('Doc Block for const missing', $stackPointer, 'VarDocBlockMissing');
 
                 return;
             }
 
-            if ($defaultValueType === null) {
-                // Let's ignore for now
-                //$phpCsFile->addError('Doc Block for const missing', $stackPointer, 'VarDocBlockMissing');
+            if ($defaultValueType === 'null') {
+                $phpCsFile->addError('Doc Block `@var` with type `...|' . $defaultValueType . '` for const missing', $stackPointer, 'VarDocBlockMissing');
 
                 return;
             }
@@ -244,6 +244,7 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         ?string $defaultValueType
     ): void {
         $error = 'Doc Block annotation @var for const missing';
+
         if ($defaultValueType === null) {
             // Let's skip for now for non-trivial cases
             //$phpCsFile->addError($error, $docBlockEndIndex, 'DocBlockMissing');
@@ -256,6 +257,13 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         }
 
         $error .= ', type `' . $defaultValueType . '` detected';
+
+        if ($defaultValueType === 'null') {
+            $phpCsFile->addError($error, $docBlockEndIndex, 'TypeMissing');
+
+            return;
+        }
+
         $fix = $phpCsFile->addFixableError($error, $docBlockEndIndex, 'WrongType');
         if (!$fix) {
             return;

--- a/Spryker/Sniffs/Commenting/DocBlockInheritSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockInheritSniff.php
@@ -21,7 +21,13 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
     use CommentingTrait;
     use SignatureTrait;
 
+    /**
+     * @var string
+     */
     protected const INHERIT_DOC = '{@inheritDoc}';
+    /**
+     * @var string
+     */
     protected const INHERIT_DOC_INVALID = '{inheritDoc}';
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagSniff.php
@@ -16,7 +16,13 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class DocBlockTagSniff implements Sniff
 {
+    /**
+     * @var string
+     */
     protected const INHERIT_DOC_FULL = '@inheritDoc';
+    /**
+     * @var string
+     */
     protected const INHERIT_DOC_FULL_INVALID = '@inheritdoc';
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -16,7 +16,13 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const ANNOTATION_START_TEXT = 'Auto-generated group annotations';
+    /**
+     * @var string
+     */
     protected const ANNOTATION_END_TEXT = 'Add your own group annotations below this line';
 
     /**

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -232,9 +232,11 @@ class DocBlockVarSniff extends AbstractSprykerSniff
             $index = $docBlockStartIndex;
         }
 
+        $indentationLevel = $this->getIndentationLevel($phpCsFile, $docBlockEndIndex);
+
         $phpCsFile->fixer->beginChangeset();
         $phpCsFile->fixer->addNewline($index);
-        $phpCsFile->fixer->addContent($index, "\t" . ' * @var ' . $defaultValueType);
+        $phpCsFile->fixer->addContent($index, str_repeat(' ', $indentationLevel * 4) . ' * @var ' . $defaultValueType);
         $phpCsFile->fixer->endChangeset();
     }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -227,7 +227,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
             return;
         }
 
-        $index = $phpCsFile->findPrevious(Tokens::$emptyTokens, $docBlockEndIndex - 1, $docBlockStartIndex, true);
+        $index = $phpCsFile->findPrevious(T_DOC_COMMENT_WHITESPACE, $docBlockEndIndex - 1, $docBlockStartIndex, true);
         if (!$index) {
             $index = $docBlockStartIndex;
         }

--- a/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
@@ -15,6 +15,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class SprykerConstantsSniff extends AbstractSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const EXPLANATION_CONSTANTS_INTERFACE = 'Declares global environment configuration keys. Do not use it for other class constants.';
 
     /**

--- a/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
@@ -18,9 +18,18 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
 {
     use UseStatementsTrait;
 
+    /**
+     * @var string
+     */
     protected const NAMESPACE_YVES = 'Yves';
+    /**
+     * @var string
+     */
     protected const NAMESPACE_ZED = 'Zed';
 
+    /**
+     * @var array
+     */
     protected const INVALID_PAIRS = [
         [
             'from' => self::NAMESPACE_YVES,

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -18,6 +18,9 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
 {
     use UseStatementsTrait;
 
+    /**
+     * @var string
+     */
     protected const NAMESPACE_PROJECT = 'Pyz';
 
     /**

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -15,6 +15,9 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class PhpSapiConstantSniff implements Sniff
 {
+    /**
+     * @var string
+     */
     protected const PHP_SAPI = 'PHP_SAPI';
 
     /**

--- a/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
+++ b/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
@@ -18,6 +18,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class AssertPrimitivesSniff extends AbstractSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const METHOD_ASSERT_SAME = 'assertSame';
 
     /**

--- a/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
+++ b/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
@@ -18,6 +18,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class ExpectExceptionSniff extends AbstractSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const METHOD_EXPECT_EXCEPTION = 'expectException';
 
     /**

--- a/Spryker/Sniffs/Testing/MockSniff.php
+++ b/Spryker/Sniffs/Testing/MockSniff.php
@@ -20,6 +20,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class MockSniff extends AbstractSprykerSniff
 {
+    /**
+     * @var string
+     */
     protected const MOCK_OBJECT = '\PHPUnit\Framework\MockObject\MockObject';
 
     /**


### PR DESCRIPTION
Part of generics major coming up

Main changes:
- Requires docblock for trivial cases, which can be auto fixed (guessed by value)
- Changes wrong `@const` to `@var`


First, we need to get all our core code in order by applying this.
Then we can move this into a patch version and add the non trivial docblocks as per 0.17 milestone.