### PR TITLE
Fix up documentation for iterable.

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -195,7 +195,7 @@ abstract class AbstractSprykerSniff implements Sniff
      * Checks if the given token scope contains a single or multiple token codes/types.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param string|array $search
+     * @param array<string|int>|string|int $search
      * @param int $start
      * @param int $end
      * @param bool $skipNested
@@ -397,7 +397,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $index
      *
      * @return int
@@ -415,7 +415,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $index
      *
      * @return int
@@ -434,7 +434,7 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $stackPointer
      *
      * @return bool
@@ -461,7 +461,7 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $stackPointer
      *
      * @return bool
@@ -577,7 +577,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $firstPosition
      * @param int $secondPosition
      *
@@ -589,7 +589,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $stackPtr
      *
      * @return int
@@ -602,7 +602,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $position
      *
      * @return int
@@ -617,10 +617,10 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $stackPtr
-     * @param array $methodProperties
-     * @param array $methodParameters
+     * @param array<string, mixed> $methodProperties
+     * @param array<array<string, mixed>> $methodParameters
      *
      * @return int
      */
@@ -657,7 +657,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param array $methodParameter
+     * @param array<string, mixed> $methodParameter
      *
      * @return int
      */

--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -445,7 +445,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
 
     /**
      * @param string $content
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $beginRange
      * @param int $endRange
      *
@@ -560,7 +560,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $currentIndex
      *
      * @return int
@@ -576,7 +576,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $currentIndex
      *
      * @return int

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -198,7 +198,7 @@ class DocBlockConstSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $token
+     * @param array<string, mixed> $token
      *
      * @return string|null
      */

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
@@ -229,7 +229,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
      *
      * @throws \RuntimeException
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function getDocBlockReturnTypesToken(File $phpCsFile, int $stackPointer): array
     {

--- a/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
@@ -354,7 +354,7 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $docBlockReturnIndex
      *
      * @return string

--- a/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
@@ -224,7 +224,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
      * @param int $docBlockStartIndex
      * @param int $docBlockEndIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function readTags(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): array
     {
@@ -257,7 +257,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $index
      *
      * @return int
@@ -281,7 +281,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $start
      * @param int $end
      *
@@ -301,7 +301,7 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $start
      * @param int $end
      *
@@ -319,8 +319,8 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $first
-     * @param array $second
+     * @param array<string, mixed> $first
+     * @param array<string, mixed> $second
      *
      * @return void
      */
@@ -358,8 +358,8 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $first
-     * @param array $second
+     * @param array<string, mixed> $first
+     * @param array<string, mixed> $second
      *
      * @return void
      */

--- a/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
@@ -25,7 +25,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     /**
      * All other tags will go above those
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $order = [
         '@deprecated',
@@ -70,9 +70,9 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tags
+     * @param array<int, array<string, mixed>> $tags
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function checkAnnotationTagOrder(array $tags): array
     {
@@ -98,8 +98,6 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
             }
 
             $tags[$i]['error'] = 'Position of ' . $tag['tag'] . ' tag too low.';
-
-            continue;
         }
 
         return $tags;
@@ -110,7 +108,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
      * @param int $docBlockStartIndex
      * @param int $docBlockEndIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function readTags(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): array
     {
@@ -143,7 +141,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $index
      *
      * @return int
@@ -167,7 +165,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $start
      * @param int $end
      *
@@ -187,7 +185,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $start
      * @param int $end
      *
@@ -207,7 +205,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $docBlockStartIndex
      * @param int $docBlockEndIndex
-     * @param array $tags
+     * @param array<int, array<string, mixed>> $tags
      *
      * @return void
      */
@@ -264,7 +262,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @return array
+     * @return array<string, int>
      */
     protected function getTagOrderMap(): array
     {

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
@@ -55,7 +55,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param array $namespaceParts
+     * @param array<string> $namespaceParts
      *
      * @return void
      */
@@ -81,7 +81,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param array $namespaceParts
+     * @param array<string> $namespaceParts
      *
      * @return void
      */
@@ -115,7 +115,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $docCommentEndPosition
-     * @param array $namespaceParts
+     * @param array<string> $namespaceParts
      *
      * @return void
      */

--- a/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -87,7 +87,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function extractExceptions(File $phpCsFile, int $stackPointer): array
     {
@@ -150,7 +150,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $docBlockStartIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function extractExceptionAnnotations(File $phpCsFile, int $docBlockStartIndex): array
     {
@@ -198,7 +198,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $contentIndex
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function extractException(File $phpCsFile, int $contentIndex): array
     {
@@ -228,8 +228,8 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $exceptions
-     * @param array $annotations
+     * @param array<int, array<string, mixed>> $exceptions
+     * @param array<int, array<string, mixed>> $annotations
      * @param int $docBlockEndIndex
      *
      * @return void
@@ -284,10 +284,10 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $exception
-     * @param array $useStatements
+     * @param array<string, mixed> $exception
+     * @param array<string, array<string, mixed>> $useStatements
      *
-     * @return array Exception
+     * @return array<string, mixed> Exception
      */
     protected function normalizeClassName(array $exception, array $useStatements): array
     {
@@ -302,9 +302,9 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $annotation
-     * @param array $exceptions
-     * @param array $useStatements
+     * @param array<string, mixed> $annotation
+     * @param array<int, array<string, mixed>> $exceptions
+     * @param array<string, array<string, mixed>> $useStatements
      *
      * @return bool
      */
@@ -322,8 +322,8 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $exception
-     * @param array $annotations
+     * @param array<string, mixed> $exception
+     * @param array<int, array<string, mixed>> $annotations
      *
      * @return bool
      */
@@ -357,7 +357,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $exception
+     * @param array<string, mixed> $exception
      * @param int $docBlockEndIndex
      *
      * @throws \Exception
@@ -384,7 +384,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $docBlockStartIndex
      *
      * @return int
@@ -421,7 +421,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $scopeOpener
      * @param int $scopeCloser
      *
@@ -445,7 +445,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $scopeOpener
      * @param int $scopeCloser
      *

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -64,7 +64,7 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param array $docBlockParams
+     * @param array<int, array<string, mixed>> $docBlockParams
      *
      * @return void
      */
@@ -141,11 +141,11 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $docBlockStartIndex
      * @param int $docBlockEndIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function getDocBlockParams(array $tokens, int $docBlockStartIndex, int $docBlockEndIndex): array
     {

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -163,7 +163,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $token
+     * @param array<string, mixed> $token
      *
      * @return string|null
      */

--- a/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVariableNullHintLastSniff.php
@@ -58,7 +58,7 @@ class DocBlockVariableNullHintLastSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $varCommentTagIndex
      * @param int $docBlockEndIndex
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      *
      * @return void
      */

--- a/Spryker/Sniffs/Commenting/DocCommentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocCommentSniff.php
@@ -22,7 +22,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class DocCommentSniff extends AbstractSprykerSniff
 {
     /**
-     * @var array
+     * @var array<string>
      */
     public $supportedTokenizers = [
         'PHP',

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -174,7 +174,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $from
      * @param int $to
      * @param string $tagType

--- a/Spryker/Sniffs/Commenting/SprykerAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerAnnotationSniff.php
@@ -85,7 +85,7 @@ class SprykerAnnotationSniff extends AbstractSprykerSniff
      * @param int $docBlockStartIndex
      * @param int $docBlockEndIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function getFixableMethodAnnotations(
         File $phpCsFile,

--- a/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
@@ -23,7 +23,7 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
     /**
      * We must support class for now, as well - for BC.
      *
-     * @return array
+     * @inheritDoc
      */
     public function register(): array
     {

--- a/Spryker/Sniffs/DependencyProvider/FacadeNotInBridgeReturnedSniff.php
+++ b/Spryker/Sniffs/DependencyProvider/FacadeNotInBridgeReturnedSniff.php
@@ -97,7 +97,7 @@ class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      *
      * @return string
      */

--- a/Spryker/Sniffs/Factory/CreateVsGetMethodsSniff.php
+++ b/Spryker/Sniffs/Factory/CreateVsGetMethodsSniff.php
@@ -139,7 +139,7 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $stackPointer
      *
      * @return bool
@@ -161,7 +161,7 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $tokens
+     * @param array<int, array<string, mixed>> $tokens
      * @param int $stackPointer
      *
      * @return bool

--- a/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
@@ -28,7 +28,7 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
     protected const NAMESPACE_ZED = 'Zed';
 
     /**
-     * @var array
+     * @var array<int, array<string, string>>
      */
     protected const INVALID_PAIRS = [
         [
@@ -77,7 +77,7 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param array $useStatement
+     * @param array<string, mixed> $useStatement
      * @param string $applicationLayer Zed, Yves, ...
      *
      * @return void

--- a/Spryker/Sniffs/Namespaces/UseStatementSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseStatementSniff.php
@@ -21,17 +21,17 @@ class UseStatementSniff implements Sniff
     use BasicsTrait;
 
     /**
-     * @var array
+     * @var array<string, array<string, mixed>>|null
      */
     protected $existingStatements;
 
     /**
-     * @var array
+     * @var array<string, array<string, mixed>>
      */
     protected $newStatements = [];
 
     /**
-     * @var array
+     * @var array<string, array<string, mixed>>|null
      */
     protected $allStatements;
 
@@ -133,7 +133,7 @@ class UseStatementSniff implements Sniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param array $statement
+     * @param array<string, mixed> $statement
      * @param int $stackPtr
      *
      * @return void
@@ -705,7 +705,7 @@ class UseStatementSniff implements Sniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      *
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     protected function getUseStatements(File $phpcsFile): array
     {
@@ -773,7 +773,7 @@ class UseStatementSniff implements Sniff
      *
      * @throws \RuntimeException
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function addUseStatement(File $phpcsFile, string $shortName, string $fullName): array
     {
@@ -803,7 +803,7 @@ class UseStatementSniff implements Sniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param array $useStatement
+     * @param array<string, mixed> $useStatement
      *
      * @return void
      */
@@ -825,7 +825,7 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param array $useStatement
+     * @param array<string, mixed> $useStatement
      *
      * @return string
      */
@@ -865,7 +865,7 @@ class UseStatementSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $extendsStartIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function parseExtends(File $phpcsFile, int $extendsStartIndex): array
     {
@@ -878,7 +878,7 @@ class UseStatementSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $implementsStartIndex
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function parseImplements(File $phpcsFile, int $implementsStartIndex): array
     {
@@ -894,7 +894,7 @@ class UseStatementSniff implements Sniff
      *
      * @throws \RuntimeException
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function parse(File $phpcsFile, int $startIndex, int $endIndex): array
     {

--- a/Spryker/Sniffs/Testing/MockSniff.php
+++ b/Spryker/Sniffs/Testing/MockSniff.php
@@ -217,7 +217,7 @@ class MockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param array $docBlockReturnTypes
+     * @param array<string> $docBlockReturnTypes
      *
      * @return bool
      */

--- a/Spryker/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -26,7 +26,13 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         $tokens = $phpcsFile->getTokens();
 
         $endIndex = $phpcsFile->findNext(T_SEMICOLON, $stackPtr + 1);
+        if (!$endIndex) {
+            return;
+        }
         $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $endIndex + 1, null, true);
+        if (!$nextIndex) {
+            return;
+        }
 
         if ($tokens[$nextIndex]['line'] - $tokens[$endIndex]['line'] === 2) {
             return;

--- a/Spryker/Tools/Tokenizer.php
+++ b/Spryker/Tools/Tokenizer.php
@@ -36,7 +36,7 @@ class Tokenizer
     protected $verbose;
 
     /**
-     * @param array $argv
+     * @param array<string> $argv
      *
      * @throws \Exception
      */
@@ -81,7 +81,7 @@ class Tokenizer
     /**
      * @param string $path Path
      *
-     * @return array Tokens
+     * @return array<int, array<string, mixed>> Tokens
      */
     protected function getTokens(string $path): array
     {
@@ -104,9 +104,9 @@ class Tokenizer
 
     /**
      * @param int $row Current row
-     * @param array $tokens Tokens array
+     * @param array<int, array<string, mixed>> $tokens Tokens array
      *
-     * @return array
+     * @return array<string>
      */
     protected function getTokenStrings(int $row, array $tokens): array
     {

--- a/Spryker/Tools/Traits/SignatureTrait.php
+++ b/Spryker/Tools/Traits/SignatureTrait.php
@@ -18,7 +18,7 @@ trait SignatureTrait
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPtr
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     protected function getMethodSignature(File $phpCsFile, int $stackPtr): array
     {

--- a/Spryker/Traits/BasicsTrait.php
+++ b/Spryker/Traits/BasicsTrait.php
@@ -13,8 +13,8 @@ use PHP_CodeSniffer\Util\Tokens;
 trait BasicsTrait
 {
     /**
-     * @param string|int|array $search
-     * @param array $token
+     * @param array<string|int>|string|int $search
+     * @param array<string, mixed> $token
      *
      * @return bool
      */
@@ -35,7 +35,7 @@ trait BasicsTrait
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      *
-     * @return array
+     * @return array<string, mixed>>
      */
     protected function getNamespaceStatement(File $phpcsFile): array
     {

--- a/Spryker/Traits/UseStatementsTrait.php
+++ b/Spryker/Traits/UseStatementsTrait.php
@@ -15,7 +15,7 @@ trait UseStatementsTrait
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      *
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     protected function getUseStatements(File $phpcsFile): array
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,4 +6,3 @@ parameters:
         - GlueStreamSpecific/
     bootstrapFiles:
         - %rootDir%/../../../tests/bootstrap.php
-    checkMissingIterableValueType: false


### PR DESCRIPTION
As per new guidelines, we do not want to use

    checkMissingIterableValueType: false

anymore in new code