### PR TITLE
Add missing sniffs that are already expected.

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractApiClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractApiClassDetectionSprykerSniff.php
@@ -15,22 +15,27 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
      * @var string
      */
     protected const API_FACADE = 'FACADE';
+
     /**
      * @var string
      */
     protected const API_SERVICE = 'SERVICE';
+
     /**
      * @var string
      */
     protected const API_CLIENT = 'CLIENT';
+
     /**
      * @var string
      */
     protected const API_QUERY_CONTAINER = 'QUERY_CONTAINER';
+
     /**
      * @var string
      */
     protected const API_PLUGIN = 'PLUGIN';
+
     /**
      * @var string
      */

--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -27,7 +27,7 @@ abstract class AbstractSprykerSniff implements Sniff
     protected const NAMESPACE_SPRYKER = 'Spryker';
 
     /**
-     * @var string[] These markers must remain as inline comments
+     * @var array<string> These markers must remain as inline comments
      */
     protected static $phpStormMarkers = [
         '@noinspection',
@@ -499,7 +499,7 @@ abstract class AbstractSprykerSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getDocBlockReturnTypes(File $phpCsFile, int $stackPointer): array
     {

--- a/Spryker/Sniffs/Arrays/DisallowImplicitArrayCreationSniff.php
+++ b/Spryker/Sniffs/Arrays/DisallowImplicitArrayCreationSniff.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use SlevomatCodingStandard\Sniffs\Arrays\DisallowImplicitArrayCreationSniff as SlevomatDisallowImplicitArrayCreationSniff;
+
+/**
+ * Customize to exclude config files (non namespaced classes)
+ */
+class DisallowImplicitArrayCreationSniff extends SlevomatDisallowImplicitArrayCreationSniff
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // We skip on config files.
+        if (strpos($phpcsFile->getFilename(), DIRECTORY_SEPARATOR . 'config_') !== false) {
+            return;
+        }
+
+        parent::process($phpcsFile, $stackPtr);
+    }
+}

--- a/Spryker/Sniffs/Classes/ClassFileNameSniff.php
+++ b/Spryker/Sniffs/Classes/ClassFileNameSniff.php
@@ -41,7 +41,7 @@ class ClassFileNameSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $fullPath = basename($phpcsFile->getFilename());
         $fileName = substr($fullPath, 0, strrpos($fullPath, '.') ?: 0);

--- a/Spryker/Sniffs/Classes/MethodArgumentDefaultValueSniff.php
+++ b/Spryker/Sniffs/Classes/MethodArgumentDefaultValueSniff.php
@@ -31,7 +31,7 @@ class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
+++ b/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
@@ -146,5 +146,6 @@ class MethodDeclarationSniff extends AbstractScopeSniff
      */
     protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
     {
+        // Nothing to be done here.
     }
 }

--- a/Spryker/Sniffs/Classes/MethodTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/MethodTypeHintSniff.php
@@ -29,7 +29,7 @@ class MethodTypeHintSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Classes/PropertyDefaultValueSniff.php
+++ b/Spryker/Sniffs/Classes/PropertyDefaultValueSniff.php
@@ -28,7 +28,7 @@ class PropertyDefaultValueSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $visibilityIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$visibilityIndex) {

--- a/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -29,7 +29,7 @@ class ReturnTypeHintSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockConstructorSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstructorSniff.php
@@ -32,7 +32,7 @@ class DocBlockConstructorSniff extends AbstractSprykerSniff
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockInheritSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockInheritSniff.php
@@ -25,6 +25,7 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
      * @var string
      */
     protected const INHERIT_DOC = '{@inheritDoc}';
+
     /**
      * @var string
      */
@@ -43,7 +44,7 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockNoEmptySniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockNoEmptySniff.php
@@ -28,7 +28,7 @@ class DocBlockNoEmptySniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockNoInlineAlignmentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockNoInlineAlignmentSniff.php
@@ -29,7 +29,7 @@ class DocBlockNoInlineAlignmentSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -164,7 +164,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
 
     /**
      * @param string $type
-     * @param string[] $pieces
+     * @param array<string> $pieces
      *
      * @return bool
      */

--- a/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
@@ -28,7 +28,7 @@ class DocBlockPipeSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
@@ -75,7 +75,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return string[]|null
+     * @return array<string>|null
      */
     protected function parseDocBlockReturnTypes(File $phpCsFile, int $stackPointer): ?array
     {
@@ -129,7 +129,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param string[] $docBlockReturnTypes
+     * @param array<string> $docBlockReturnTypes
      *
      * @return void
      */
@@ -155,7 +155,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param string[] $docBlockReturnTypes
+     * @param array<string> $docBlockReturnTypes
      *
      * @return void
      */

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -87,8 +87,8 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $classNameIndex
-     * @param string[] $parts
-     * @param string[] $returnTypes
+     * @param array<string> $parts
+     * @param array<string> $returnTypes
      * @param string $appendix
      *
      * @return void
@@ -174,9 +174,9 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $classNameIndex
-     * @param string[] $parts
+     * @param array<string> $parts
      * @param string $appendix
-     * @param string[] $returnTypes
+     * @param array<string> $returnTypes
      *
      * @return void
      */
@@ -226,7 +226,7 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getReturnTypes(File $phpCsFile, int $stackPointer): array
     {
@@ -286,8 +286,8 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param string[] $parts
-     * @param string[] $returnTypes
+     * @param array<string> $parts
+     * @param array<string> $returnTypes
      *
      * @return void
      */

--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -30,7 +30,7 @@ class DocBlockReturnTagSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
@@ -21,7 +21,7 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
     use CommentingTrait;
 
     /**
-     * @var string[]
+     * @var array<string>
      */
     protected $ignored = [
         '__construct',
@@ -39,7 +39,7 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockSniff.php
@@ -33,7 +33,7 @@ class DocBlockSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockStructureSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockStructureSniff.php
@@ -33,7 +33,7 @@ class DocBlockStructureSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockTagIterableSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagIterableSniff.php
@@ -32,7 +32,7 @@ class DocBlockTagIterableSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagSniff.php
@@ -20,6 +20,7 @@ class DocBlockTagSniff implements Sniff
      * @var string
      */
     protected const INHERIT_DOC_FULL = '@inheritDoc';
+
     /**
      * @var string
      */
@@ -38,7 +39,7 @@ class DocBlockTagSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -20,6 +20,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
      * @var string
      */
     protected const ANNOTATION_START_TEXT = 'Auto-generated group annotations';
+
     /**
      * @var string
      */
@@ -71,7 +72,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param string[] $expectedGroupAnnotations
+     * @param array<string> $expectedGroupAnnotations
      *
      * @return void
      */
@@ -97,7 +98,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
-     * @param string[] $expectedAnnotations
+     * @param array<string> $expectedAnnotations
      *
      * @return void
      */
@@ -134,7 +135,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $docCommentEndPosition
-     * @param string[] $namespaceParts
+     * @param array<string> $namespaceParts
      *
      * @return void
      */
@@ -167,7 +168,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getNamespaceParts(File $phpCsFile, int $stackPointer): array
     {
@@ -240,9 +241,9 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string[] $namespaceParts
+     * @param array<string> $namespaceParts
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getExpectedAnnotations(File $phpCsFile, array $namespaceParts): array
     {
@@ -348,8 +349,8 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param string[] $givenGroupAnnotationParts
-     * @param string[] $expectedGroupAnnotations
+     * @param array<string> $givenGroupAnnotationParts
+     * @param array<string> $expectedGroupAnnotations
      *
      * @return bool
      */

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
@@ -153,7 +153,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getNamespaceParts(File $phpCsFile, int $stackPointer): array
     {
@@ -191,7 +191,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $stackPointer
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getGroupAnnotationParts(File $phpCsFile, int $stackPointer): array
     {

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -26,7 +26,7 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     /**
      * Highest/First element will be last in list of param or return tag.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $sortMap = [
         'void',
@@ -103,9 +103,9 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     /**
      * @uses DocBlockTypeOrderSniff::compare()
      *
-     * @param string[] $elements
+     * @param array<string> $elements
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getExpectedOrder(array $elements): array
     {

--- a/Spryker/Sniffs/Commenting/DocCommentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocCommentSniff.php
@@ -40,7 +40,7 @@ class DocCommentSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -19,7 +19,7 @@ class FileDocBlockSniff extends AbstractSprykerSniff
     /**
      * This property can be filled within the ruleset configuration file
      *
-     * @var string[]
+     * @var array<string>
      */
     public $ignorableModules = [];
 
@@ -28,7 +28,7 @@ class FileDocBlockSniff extends AbstractSprykerSniff
      *
      * Overwrite by adding a custom .license file to the repository root.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected static $defaultLicense = [
         'Copyright © 2016-present Spryker Systems GmbH. All rights reserved.',
@@ -38,7 +38,7 @@ class FileDocBlockSniff extends AbstractSprykerSniff
     /**
      * Cache of licenses to avoid file lookups.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $licenseMap = [];
 
@@ -345,7 +345,7 @@ class FileDocBlockSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int|null $fileDocBlockStartPosition
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function getFileDocBlockLines(File $phpCsFile, ?int $fileDocBlockStartPosition): array
     {
@@ -378,7 +378,7 @@ class FileDocBlockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param string[] $licenseLines
+     * @param array<string> $licenseLines
      *
      * @return string
      */

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class FullyQualifiedClassNameInDocBlockSniff implements Sniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public static $whitelistedTypes = [
         'string', 'int', 'integer', 'float', 'bool', 'boolean', 'resource', 'null', 'void', 'callable',
@@ -24,7 +24,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     ];
 
     /**
-     * @var string[]
+     * @var array<string>
      */
     public static $whitelistedStartsWithTypes = ['array<', 'iterable<', 'array{'];
 
@@ -106,7 +106,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $classNameIndex
-     * @param string[] $classNames
+     * @param array<string> $classNames
      * @param string $appendix
      *
      * @return void
@@ -134,9 +134,9 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $classNameIndex
-     * @param string[] $classNames
+     * @param array<string> $classNames
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function generateClassNameMap(File $phpCsFile, int $classNameIndex, array &$classNames): array
     {
@@ -301,7 +301,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function parseUseStatements(File $phpCsFile): array
     {
@@ -348,7 +348,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
      *
      * @param string $content
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function parseTypes(string $content): array
     {
@@ -379,7 +379,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param int $classNameIndex
      * @param string $className
-     * @param string[] $subClassNames
+     * @param array<string> $subClassNames
      *
      * @return string
      */

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -172,7 +172,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
      * @param int $contentIndex
      * @param bool $isSingleLine
      *
-     * @return string[]
+     * @return array<string>
      */
     protected function findErrors(File $phpCsFile, int $contentIndex, bool $isSingleLine): array
     {

--- a/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -37,7 +37,7 @@ class ControlStructureSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $this->checkTryToken($phpcsFile, $stackPtr);
         $this->checkCatchToken($phpcsFile, $stackPtr);

--- a/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
+++ b/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
@@ -28,7 +28,7 @@ class NoInlineAssignmentSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$stackPtr]['code'] === T_OBJECT_OPERATOR || $tokens[$stackPtr]['code'] === T_DOUBLE_COLON) {

--- a/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
+++ b/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
@@ -37,7 +37,7 @@ class ArrayDeclarationSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Formatting/MethodSignatureParametersLineBreakMethodSniff.php
+++ b/Spryker/Sniffs/Formatting/MethodSignatureParametersLineBreakMethodSniff.php
@@ -43,7 +43,7 @@ class MethodSignatureParametersLineBreakMethodSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
         $openParenthesisPosition = $tokens[$stackPtr]['parenthesis_opener'];

--- a/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
@@ -31,7 +31,7 @@ class SprykerNoDemoshopSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         if (!$this->isDemoshopCode($phpcsFile)) {
             return;

--- a/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
@@ -26,7 +26,7 @@ class FunctionNamespaceSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -29,7 +29,7 @@ class SprykerNamespaceSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $namespaceStatement = $this->getNamespaceStatement($phpcsFile);
         if (!$namespaceStatement) {

--- a/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
@@ -22,6 +22,7 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
      * @var string
      */
     protected const NAMESPACE_YVES = 'Yves';
+
     /**
      * @var string
      */
@@ -52,7 +53,7 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $className = $this->getClassName($phpcsFile);
         $namespaces = [];

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -34,7 +34,7 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         if (!$this->isSprykerNamespace($phpcsFile)) {
             return;

--- a/Spryker/Sniffs/Namespaces/UseStatementSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseStatementSniff.php
@@ -51,7 +51,7 @@ class UseStatementSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Namespaces/UseWithAliasingSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseWithAliasingSniff.php
@@ -29,7 +29,7 @@ class UseWithAliasingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
@@ -16,12 +16,12 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class DisallowFunctionsSniff implements Sniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public static $disallowed = [];
 
     /**
-     * @var int[]
+     * @var array<int>
      */
     protected static $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
 
@@ -36,7 +36,7 @@ class DisallowFunctionsSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $this->checkForbiddenFunctions($phpcsFile, $stackPtr);
         $this->checkImplodeUsage($phpcsFile, $stackPtr);

--- a/Spryker/Sniffs/PHP/ExitSniff.php
+++ b/Spryker/Sniffs/PHP/ExitSniff.php
@@ -18,7 +18,7 @@ class ExitSniff implements Sniff
     /**
      * @see http://php.net/manual/en/aliases.php
      *
-     * @var string[]
+     * @var array<string>
      */
     public static $aliases = [
         'die' => 'exit',
@@ -35,7 +35,7 @@ class ExitSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $this->checkExitUsage($phpcsFile, $stackPtr);
     }

--- a/Spryker/Sniffs/PHP/NoIsNullSniff.php
+++ b/Spryker/Sniffs/PHP/NoIsNullSniff.php
@@ -27,7 +27,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
 

--- a/Spryker/Sniffs/PHP/NotEqualSniff.php
+++ b/Spryker/Sniffs/PHP/NotEqualSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class NotEqualSniff implements Sniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public static $matching = [
         '<>' => '!=',
@@ -33,7 +33,7 @@ class NotEqualSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -31,7 +31,7 @@ class PhpSapiConstantSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
+++ b/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
@@ -16,7 +16,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class PreferCastOverFunctionSniff extends AbstractSprykerSniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     protected static $matching = [
         'strval' => 'string',
@@ -36,7 +36,7 @@ class PreferCastOverFunctionSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
 

--- a/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -18,7 +18,7 @@ class RemoveFunctionAliasSniff implements Sniff
     /**
      * @see http://php.net/manual/en/aliases.php
      *
-     * @var string[]
+     * @var array<string>
      */
     public static $matching = [
         'is_integer' => 'is_int',
@@ -48,7 +48,7 @@ class RemoveFunctionAliasSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $this->checkFixableAliases($phpcsFile, $stackPtr);
     }

--- a/Spryker/Sniffs/PHP/ShortCastSniff.php
+++ b/Spryker/Sniffs/PHP/ShortCastSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class ShortCastSniff implements Sniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public static $matching = [
         '(boolean)' => '(bool)',
@@ -34,7 +34,7 @@ class ShortCastSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/PHP/SingleQuoteSniff.php
+++ b/Spryker/Sniffs/PHP/SingleQuoteSniff.php
@@ -40,7 +40,7 @@ class SingleQuoteSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
+++ b/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
@@ -24,7 +24,7 @@ class AssertPrimitivesSniff extends AbstractSprykerSniff
     protected const METHOD_ASSERT_SAME = 'assertSame';
 
     /**
-     * @var string[]
+     * @var array<string>
      */
     protected static $primitives = [
         'null',
@@ -43,7 +43,7 @@ class AssertPrimitivesSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         if (!$this->isTest($phpcsFile, $stackPtr)) {
             return;

--- a/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
+++ b/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
@@ -34,7 +34,7 @@ class ExpectExceptionSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         if (!$this->isTest($phpcsFile, $stackPtr)) {
             return;

--- a/Spryker/Sniffs/Testing/MockSniff.php
+++ b/Spryker/Sniffs/Testing/MockSniff.php
@@ -36,7 +36,7 @@ class MockSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         if (!$this->isTest($phpcsFile, $stackPtr)) {
             return;
@@ -53,7 +53,7 @@ class MockSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
      * @param \SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
-     * @param string[] $docBlockReturnTypes
+     * @param array<string> $docBlockReturnTypes
      *
      * @return void
      */
@@ -102,7 +102,7 @@ class MockSniff extends AbstractSprykerSniff
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
-     * @param string[] $docBlockReturnTypes
+     * @param array<string> $docBlockReturnTypes
      * @param \SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
      *
      * @return void

--- a/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -29,7 +29,7 @@ class CommaSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
@@ -37,7 +37,7 @@ class ConcatenationSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/DocBlockSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/DocBlockSpacingSniff.php
@@ -29,7 +29,7 @@ class DocBlockSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
@@ -30,7 +30,7 @@ class EmptyEnclosingLineSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
         $errorData = [strtolower($tokens[$stackPtr]['content'])];

--- a/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -19,7 +19,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class EmptyLinesSniff extends AbstractSprykerSniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public $supportedTokenizers = [
         'PHP',
@@ -38,7 +38,7 @@ class EmptyLinesSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $this->assertMaximumOneEmptyLineBetweenContent($phpcsFile, $stackPtr);
     }

--- a/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -27,7 +27,7 @@ class ImplicitCastSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
@@ -29,7 +29,7 @@ class MethodSpacingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/NamespaceSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/NamespaceSpacingSniff.php
@@ -29,7 +29,7 @@ class NamespaceSpacingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/ObjectAttributeSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ObjectAttributeSpacingSniff.php
@@ -29,7 +29,7 @@ class ObjectAttributeSpacingSniff implements Sniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -20,7 +20,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class OperatorSpacingSniff extends AbstractSprykerSniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public $supportedTokenizers = [
         'PHP',
@@ -42,7 +42,7 @@ class OperatorSpacingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Sniffs/WhiteSpace/TernarySpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/TernarySpacingSniff.php
@@ -19,7 +19,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class TernarySpacingSniff extends AbstractSprykerSniff
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     public $supportedTokenizers = [
         'PHP',
@@ -38,7 +38,7 @@ class TernarySpacingSniff extends AbstractSprykerSniff
     /**
      * @inheritDoc
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Spryker/Tools/Traits/CommentingTrait.php
+++ b/Spryker/Tools/Traits/CommentingTrait.php
@@ -52,7 +52,7 @@ trait CommentingTrait
     /**
      * Allow \Foo\Bar[] or array<\Foo\Bar> to pass as array.
      *
-     * @param string[] $docBlockTypes
+     * @param array<string> $docBlockTypes
      *
      * @return bool
      */
@@ -70,7 +70,7 @@ trait CommentingTrait
     /**
      * Checks for ...<...>.
      *
-     * @param string[] $docBlockTypes
+     * @param array<string> $docBlockTypes
      *
      * @return bool
      */

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -21,6 +21,8 @@
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
 
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>
             <property name="allowFallbackGlobalFunctions" type="boolean" value="true"/>
@@ -34,6 +36,9 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
 
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+    <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
+
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
@@ -41,6 +46,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
+    <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
             <property name="fixable" type="bool" value="true"/>
@@ -113,6 +119,7 @@
             <property name="ignoreBlankLines" value="false"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
 
     <rule ref="Zend.Files.ClosingTag"/>
     <rule ref="Generic.Files.LineEndings"/>
@@ -189,8 +196,10 @@
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 
-    <!-- Disallow PHP8 specific behavior until code is PHP8+ only -->
+    <!-- Disallow PHP8 specific behavior until code is PHP8+ only, projects can remove/silence those -->
     <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
     <rule ref="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 208 sniffs
+The SprykerStrict standard contains 217 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -75,11 +75,14 @@ PSR2 (12 sniffs)
 - PSR2.Namespaces.NamespaceDeclaration
 - PSR2.Namespaces.UseDeclaration
 
-SlevomatCodingStandard (31 sniffs)
+SlevomatCodingStandard (39 sniffs)
 ----------------------------------
+- SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement
+- SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
 - SlevomatCodingStandard.Classes.ClassMemberSpacing
+- SlevomatCodingStandard.Classes.ConstantSpacing
 - SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion
 - SlevomatCodingStandard.Classes.ModernClassNameReference
 - SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment
@@ -91,14 +94,18 @@ SlevomatCodingStandard (31 sniffs)
 - SlevomatCodingStandard.ControlStructures.NewWithParentheses
 - SlevomatCodingStandard.Exceptions.DeadCatch
 - SlevomatCodingStandard.Functions.ArrowFunctionDeclaration
+- SlevomatCodingStandard.Functions.DisallowNamedArguments
+- SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall
 - SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration
 - SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
 - SlevomatCodingStandard.Namespaces.NamespaceDeclaration
 - SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+- SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile
 - SlevomatCodingStandard.Namespaces.UnusedUses
 - SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash
 - SlevomatCodingStandard.Namespaces.UseFromSameNamespace
 - SlevomatCodingStandard.Namespaces.UseSpacing
+- SlevomatCodingStandard.Namespaces.UselessAlias
 - SlevomatCodingStandard.PHP.ForbiddenClasses
 - SlevomatCodingStandard.PHP.ShortList
 - SlevomatCodingStandard.PHP.TypeCast
@@ -108,9 +115,11 @@ SlevomatCodingStandard (31 sniffs)
 - SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
+- SlevomatCodingStandard.Whitespaces.DuplicateSpaces
 
-Spryker (89 sniffs)
+Spryker (90 sniffs)
 -------------------
+- Spryker.Arrays.DisallowImplicitArrayCreation
 - Spryker.Classes.ClassFileName
 - Spryker.Classes.MethodArgumentDefaultValue
 - Spryker.Classes.MethodDeclaration


### PR DESCRIPTION
Also fix up generics to not have `\Object<type>`, but `\Object|type[]` until IDEs understand it.