### PR TITLE
Add Assignment in Conditions sniff

### DIFF
--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -61,6 +61,7 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
 
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
 


### PR DESCRIPTION
Resolves https://github.com/spryker/code-sniffer/issues/290

This has always been disallowed as practice as it can too easily happen as human error on missing one = in a condition.
Always assign first to local var, then compare.