### PR TITLE
TE-10370 Add DisallowCloakingCheck sniff.

### DIFF
--- a/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
+++ b/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
@@ -131,10 +131,10 @@ class MethodDeclarationSniff extends AbstractScopeSniff
         }
 
         // Batch all the fixes together to reduce the possibility of conflicts.
-        if (empty($fixes) === false) {
+        if ($fixes) {
             $phpcsFile->fixer->beginChangeset();
-            foreach ($fixes as $stackPtr => $content) {
-                $phpcsFile->fixer->replaceToken($stackPtr, $content);
+            foreach ($fixes as $index => $content) {
+                $phpcsFile->fixer->replaceToken($index, $content);
             }
 
             $phpcsFile->fixer->endChangeset();

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -112,7 +112,7 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         }
 
         $content = $tokens[$typeIndex]['content'];
-        if (empty($content)) {
+        if (!$content) {
             $error = 'Doc Block type for property annotation @var missing';
             if ($defaultValueType) {
                 $error .= ', type `' . $defaultValueType . '` detected';

--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -79,7 +79,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             }
 
             $content = $tokens[$classNameIndex]['content'];
-            if (empty($content)) {
+            if (!$content) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockParamNotJustNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamNotJustNullSniff.php
@@ -82,7 +82,7 @@ class DocBlockParamNotJustNullSniff extends AbstractSprykerSniff
                 $appendix = substr($content, $spaceIndex);
                 $content = substr($content, 0, $spaceIndex);
             }
-            if (empty($content) || $content !== 'null') {
+            if (!$content || $content !== 'null') {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
@@ -59,7 +59,7 @@ class DocBlockPipeSpacingSniff implements Sniff
 
         $desc = ltrim($description);
 
-        while (!empty($desc) && mb_substr($desc, 0, 1) === '|') {
+        while ($desc && mb_substr($desc, 0, 1) === '|') {
             $desc = ltrim(mb_substr($desc, 1));
 
             $pos = mb_strpos($desc, ' ');

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullSniff.php
@@ -83,7 +83,7 @@ class DocBlockReturnNullSniff implements Sniff
             }
 
             $content = $tokens[$classNameIndex]['content'];
-            if (empty($content)) {
+            if (!$content) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -66,7 +66,7 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
                 $content = substr($content, 0, $spaceIndex);
             }
 
-            if (empty($content)) {
+            if (!$content) {
                 continue;
             }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVarNotJustNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarNotJustNullSniff.php
@@ -77,7 +77,7 @@ class DocBlockVarNotJustNullSniff extends AbstractSprykerSniff
             $content = substr($content, 0, $spaceIndex);
         }
 
-        if (empty($content)) {
+        if (!$content) {
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -96,7 +96,7 @@ class DocBlockVarSniff extends AbstractSprykerSniff
             $content = substr($content, 0, $spaceIndex);
         }
 
-        if (empty($content)) {
+        if (!$content) {
             $error = 'Doc Block type for property annotation @var missing';
             if ($defaultValueType) {
                 $error .= ', type `' . $defaultValueType . '` detected';

--- a/Spryker/Sniffs/Commenting/TypeHintSniff.php
+++ b/Spryker/Sniffs/Commenting/TypeHintSniff.php
@@ -148,7 +148,7 @@ class TypeHintSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            /** @phpstan-var \PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
+            /** @phpstan-var \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode|\PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
             if ($valueNode->type instanceof UnionTypeNode) {
                 $types = $valueNode->type->types;
             } elseif ($valueNode->type instanceof ArrayTypeNode) {

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -73,7 +73,11 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
 
         $inverted = false;
         $previousTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($previousTokenIndex && $tokens[$previousTokenIndex]['code'] === T_BOOLEAN_NOT) {
+        if (!$previousTokenIndex) {
+            return;
+        }
+
+        if ($tokens[$previousTokenIndex]['code'] === T_BOOLEAN_NOT) {
             $inverted = true;
         }
 
@@ -92,7 +96,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
             return;
         }
 
-        if ($inverted && $previousTokenIndex) {
+        if ($inverted) {
             $fix = $phpcsFile->addFixableError($message, $stackPtr, 'InvalidEmpty');
             if (!$fix) {
                 return;
@@ -120,12 +124,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
 
         $phpcsFile->fixer->beginChangeset();
 
-        if ($inverted && $previousTokenIndex) {
-            $phpcsFile->fixer->replaceToken($previousTokenIndex, '');
-            $phpcsFile->fixer->replaceToken($stackPtr, '');
-        } else {
-            $phpcsFile->fixer->replaceToken($stackPtr, '!');
-        }
+        $phpcsFile->fixer->replaceToken($stackPtr, '!');
 
         $phpcsFile->fixer->replaceToken($openingBraceIndex, '');
         $phpcsFile->fixer->replaceToken($closingBraceIndex, '');
@@ -156,6 +155,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         }
 
         $keys = array_keys($nestedParenthesis);
+        /** @var int $index */
         $index = array_shift($keys);
 
         $conditionalTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($index - 1), null, true);

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -26,6 +26,14 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
     }
 
     /**
+     * @var array<string>
+     */
+    protected $validTokens = [
+        T_CLOSE_SQUARE_BRACKET,
+        T_CLOSE_CURLY_BRACKET,
+    ];
+
+    /**
      * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr): void
@@ -46,12 +54,9 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
 
         $lastValueIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closingBraceIndex - 1), $valueIndex, true) ?: $valueIndex;
 
-        $validTokens = [
-            T_CLOSE_SQUARE_BRACKET,
-        ];
         $validSilencing = false;
         for ($i = $valueIndex; $i <= $lastValueIndex; $i++) {
-            if (in_array($tokens[$i]['code'], $validTokens, true)) {
+            if (in_array($tokens[$i]['code'], $this->validTokens, true)) {
                 $validSilencing = true;
 
                 break;

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -18,6 +18,13 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 class DisallowCloakingCheckSniff extends AbstractSprykerSniff
 {
     /**
+     * Use this to make this sniff more strict regarding object var references.
+     *
+     * @var bool
+     */
+    public $strict = false;
+
+    /**
      * @inheritDoc
      */
     public function register(): array
@@ -182,6 +189,10 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         }
 
         if (!$objectOperatorIndex) {
+            return false;
+        }
+
+        if ($this->strict) {
             return false;
         }
 

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -99,7 +99,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
 
         $phpcsFile->fixer->beginChangeset();
 
-        if ($inverted) {
+        if ($inverted && $previousTokenIndex) {
             $phpcsFile->fixer->replaceToken($previousTokenIndex, '');
             $phpcsFile->fixer->replaceToken($stackPtr, '');
         } else {
@@ -112,31 +112,4 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
-    protected function checkMethodCalls(File $phpcsFile, int $stackPtr): void
-    {
-        $tokens = $phpcsFile->getTokens();
-
-        $openingBraceIndex = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), $stackPtr + 4);
-        if (!$openingBraceIndex) {
-            return;
-        }
-        if (empty($tokens[$openingBraceIndex]['parenthesis_closer'])) {
-            return;
-        }
-
-        $closingBraceIndex = $tokens[$openingBraceIndex]['parenthesis_closer'];
-
-        $hasInlineAssignment = $this->contains($phpcsFile, T_EQUAL, $openingBraceIndex + 1, $closingBraceIndex - 1);
-        if (!$hasInlineAssignment) {
-            return;
-        }
-
-        $phpcsFile->addError('Inline assignment not allowed', $stackPtr, 'NoInlineAssignment');
-    }
 }

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
+
+/**
+ * Cloaking checks are only valid for cases where the key can be undefined.
+ * It is not allowed on variables (define them first) or functions/methods (use *exists check).
+ */
+class DisallowCloakingCheckSniff extends AbstractSprykerSniff
+{
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [T_ISSET, T_EMPTY];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $openingBraceIndex = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if (!$openingBraceIndex) {
+            return;
+        }
+
+        $closingBraceIndex = $tokens[$openingBraceIndex]['parenthesis_closer'];
+
+        $valueIndex = $phpcsFile->findNext(Tokens::$emptyTokens, ($openingBraceIndex + 1), ($closingBraceIndex - 1), true);
+        if (!$valueIndex) {
+            return;
+        }
+
+        $lastValueIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closingBraceIndex - 1), $valueIndex, true) ?: $valueIndex;
+
+        $validTokens = [
+            T_CLOSE_SQUARE_BRACKET,
+        ];
+        $validSilencing = false;
+        for ($i = $valueIndex; $i <= $lastValueIndex; $i++) {
+            if (in_array($tokens[$i]['code'], $validTokens, true)) {
+                $validSilencing = true;
+
+                break;
+            }
+        }
+
+        if ($validSilencing) {
+            return;
+        }
+
+        $inverted = false;
+        $previousTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($previousTokenIndex && $tokens[$previousTokenIndex]['code'] === T_BOOLEAN_NOT) {
+            $inverted = true;
+        }
+
+        $message = sprintf('Cloaking `%s()` check is not allowed for non-silencing needs.', $tokens[$stackPtr]['content']);
+
+        if ($tokens[$stackPtr]['content'] === 'isset') {
+            $phpcsFile->addError($message, $stackPtr, 'InvalidIsset');
+
+            return;
+        }
+
+        $nextTokenIndex = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingBraceIndex + 1), null, true);
+        if ($nextTokenIndex && in_array($tokens[$nextTokenIndex]['code'], Tokens::$equalityTokens, true)) {
+            $phpcsFile->addError($message, $stackPtr, 'InvalidEmpty');
+
+            return;
+        }
+
+        if ($inverted && $previousTokenIndex) {
+            $assignmentTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousTokenIndex - 1), null, true);
+            if ($assignmentTokenIndex && in_array($tokens[$assignmentTokenIndex]['code'], [T_EQUAL, T_RETURN], true)) {
+                $phpcsFile->addError($message, $stackPtr, 'InvalidEmpty');
+
+                return;
+            }
+        }
+
+        $fix = $phpcsFile->addFixableError($message, $stackPtr, 'FixableEmpty');
+        if (!$fix) {
+            return;
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+
+        if ($inverted) {
+            $phpcsFile->fixer->replaceToken($previousTokenIndex, '');
+            $phpcsFile->fixer->replaceToken($stackPtr, '');
+        } else {
+            $phpcsFile->fixer->replaceToken($stackPtr, '!');
+        }
+
+        $phpcsFile->fixer->replaceToken($openingBraceIndex, '');
+        $phpcsFile->fixer->replaceToken($closingBraceIndex, '');
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return void
+     */
+    protected function checkMethodCalls(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $openingBraceIndex = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), $stackPtr + 4);
+        if (!$openingBraceIndex) {
+            return;
+        }
+        if (empty($tokens[$openingBraceIndex]['parenthesis_closer'])) {
+            return;
+        }
+
+        $closingBraceIndex = $tokens[$openingBraceIndex]['parenthesis_closer'];
+
+        $hasInlineAssignment = $this->contains($phpcsFile, T_EQUAL, $openingBraceIndex + 1, $closingBraceIndex - 1);
+        if (!$hasInlineAssignment) {
+            return;
+        }
+
+        $phpcsFile->addError('Inline assignment not allowed', $stackPtr, 'NoInlineAssignment');
+    }
+}

--- a/Spryker/Tools/Tokenizer.php
+++ b/Spryker/Tools/Tokenizer.php
@@ -140,7 +140,7 @@ class Tokenizer
                 $tokenList = [];
                 foreach ($token as $k => $v) {
                     if (is_array($v)) {
-                        if (empty($v)) {
+                        if (!$v) {
                             continue;
                         }
                         $v = json_encode($v);

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 230 sniffs
+The SprykerStrict standard contains 231 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -125,7 +125,7 @@ SlevomatCodingStandard (47 sniffs)
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 - SlevomatCodingStandard.Whitespaces.DuplicateSpaces
 
-Spryker (95 sniffs)
+Spryker (96 sniffs)
 -------------------
 - Spryker.Arrays.DisallowImplicitArrayCreation
 - Spryker.Classes.ClassFileName
@@ -174,6 +174,7 @@ Spryker (95 sniffs)
 - Spryker.Commenting.TypeHint
 - Spryker.ControlStructures.ConditionalExpressionOrder
 - Spryker.ControlStructures.ControlStructureSpacing
+- Spryker.ControlStructures.DisallowCloakingCheck
 - Spryker.ControlStructures.NoInlineAssignment
 - Spryker.DependencyProvider.FacadeNotInBridgeReturned
 - Spryker.Factory.CreateVsGetMethods

--- a/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
+++ b/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
@@ -17,7 +17,7 @@ class DisallowCloakingCheckSniffTest extends TestCase
      */
     public function testDisallowArrayTypeHintSyntaxSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 12);
+        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 10);
     }
 
     /**

--- a/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
+++ b/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
@@ -17,7 +17,7 @@ class DisallowCloakingCheckSniffTest extends TestCase
      */
     public function testDisallowArrayTypeHintSyntaxSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 4);
+        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 8);
     }
 
     /**

--- a/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
+++ b/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
@@ -17,7 +17,7 @@ class DisallowCloakingCheckSniffTest extends TestCase
      */
     public function testDisallowArrayTypeHintSyntaxSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 8);
+        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 12);
     }
 
     /**

--- a/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
+++ b/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeSnifferTest\Spryker\Sniffs\ControlStructures;
+
+use CodeSnifferTest\TestCase;
+use Spryker\Sniffs\ControlStructures\DisallowCloakingCheckSniff;
+
+class DisallowCloakingCheckSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testDisallowArrayTypeHintSyntaxSniffer(): void
+    {
+        $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 4);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocBlockThrowsFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new DisallowCloakingCheckSniff());
+    }
+}

--- a/tests/_data/DisallowCloakingCheck/after.php
+++ b/tests/_data/DisallowCloakingCheck/after.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace Spryker;
+
+class FixMe
+{
+    public function test()
+    {
+        $x = null;
+        if (!$x) {
+        }
+
+        if ($customerBlacklistIds) {
+        }
+
+        if (!$this->ok()) {
+        }
+
+        if (
+            $this->foo('x', 'y')
+            || $this->ok()
+        ) {
+        }
+
+        if (!isset($this->prop)) {
+        }
+
+        $x = (bool)$this->prop;
+
+        return (bool)$x;
+    }
+
+    public function complex($successTable)
+    {
+        return [
+            'renderSuccessTable' => empty($successTable->getData()) !== true,
+        ];
+    }
+
+    public function ok()
+    {
+        $x = [];
+        if (!empty($x['y'])) {
+        }
+    }
+}

--- a/tests/_data/DisallowCloakingCheck/after.php
+++ b/tests/_data/DisallowCloakingCheck/after.php
@@ -22,12 +22,20 @@ class FixMe
         ) {
         }
 
+        $foo->_if((bool)$filterByCompanyBusinessUnitIds);
+
         if (!isset($this->prop)) {
         }
 
         $x = (bool)$this->prop;
 
         return (bool)$x;
+    }
+
+    public function simplify()
+    {
+        if (empty($iso2Code) === false) {}
+        if (isset($iso2Code) === true) {}
     }
 
     public function complex($successTable)
@@ -48,7 +56,10 @@ class FixMe
     {
         $y = 'y';
         $x = [];
-        if (!isset($x->{$y})) {
-        }
+        if (!isset($x->{$y})) {}
+
+        if (!isset($xmlProcess->events)) {}
+
+        if (empty($_SESSION)) {}
     }
 }

--- a/tests/_data/DisallowCloakingCheck/after.php
+++ b/tests/_data/DisallowCloakingCheck/after.php
@@ -43,4 +43,12 @@ class FixMe
         if (!empty($x['y'])) {
         }
     }
+
+    public function ignoreForNow()
+    {
+        $y = 'y';
+        $x = [];
+        if (!isset($x->{$y})) {
+        }
+    }
 }

--- a/tests/_data/DisallowCloakingCheck/before.php
+++ b/tests/_data/DisallowCloakingCheck/before.php
@@ -22,12 +22,20 @@ class FixMe
         ) {
         }
 
+        $foo->_if(!empty($filterByCompanyBusinessUnitIds));
+
         if (!isset($this->prop)) {
         }
 
         $x = !empty($this->prop);
 
         return !empty($x);
+    }
+
+    public function simplify()
+    {
+        if (empty($iso2Code) === false) {}
+        if (isset($iso2Code) === true) {}
     }
 
     public function complex($successTable)
@@ -48,7 +56,10 @@ class FixMe
     {
         $y = 'y';
         $x = [];
-        if (!isset($x->{$y})) {
-        }
+        if (!isset($x->{$y})) {}
+
+        if (!isset($xmlProcess->events)) {}
+
+        if (empty($_SESSION)) {}
     }
 }

--- a/tests/_data/DisallowCloakingCheck/before.php
+++ b/tests/_data/DisallowCloakingCheck/before.php
@@ -43,4 +43,12 @@ class FixMe
         if (!empty($x['y'])) {
         }
     }
+
+    public function ignoreForNow()
+    {
+        $y = 'y';
+        $x = [];
+        if (!isset($x->{$y})) {
+        }
+    }
 }

--- a/tests/_data/DisallowCloakingCheck/before.php
+++ b/tests/_data/DisallowCloakingCheck/before.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace Spryker;
+
+class FixMe
+{
+    public function test()
+    {
+        $x = null;
+        if (empty($x)) {
+        }
+
+        if (!empty($customerBlacklistIds)) {
+        }
+
+        if (empty($this->ok())) {
+        }
+
+        if (
+            !empty($this->foo('x', 'y'))
+            || $this->ok()
+        ) {
+        }
+
+        if (!isset($this->prop)) {
+        }
+
+        $x = !empty($this->prop);
+
+        return !empty($x);
+    }
+
+    public function complex($successTable)
+    {
+        return [
+            'renderSuccessTable' => empty($successTable->getData()) !== true,
+        ];
+    }
+
+    public function ok()
+    {
+        $x = [];
+        if (!empty($x['y'])) {
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/spryker/code-sniffer/issues/305

- [x] Allow strict "false" (default) for empty()/isset() with certain cases

WIP/Follow-Up topics:

- `empty($x) === false` to `$x` / `!empty($x) === false` to `!$x` etc