### PR TITLE
Allow UselessParenthesesSniff with basic config

### DIFF
--- a/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
+++ b/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
@@ -52,13 +52,13 @@ class MethodDeclarationSniff extends AbstractScopeSniff
 
         $find = Tokens::$methodPrefixes;
         $find[] = T_WHITESPACE;
-        $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true);
         if (!$prev) {
             return;
         }
 
         $prefix = $stackPtr;
-        while (($prefix = $phpcsFile->findPrevious(Tokens::$methodPrefixes, ($prefix - 1), $prev)) !== false) {
+        while (($prefix = $phpcsFile->findPrevious(Tokens::$methodPrefixes, $prefix - 1, $prev)) !== false) {
             switch ($tokens[$prefix]['code']) {
                 case T_STATIC:
                     $static = $prefix;
@@ -86,7 +86,7 @@ class MethodDeclarationSniff extends AbstractScopeSniff
             $fix = $phpcsFile->addFixableError($error, $final, 'FinalAfterVisibility');
             if ($fix === true) {
                 $fixes[$final] = '';
-                $fixes[($final + 1)] = '';
+                $fixes[$final + 1] = '';
                 if (isset($fixes[$visibility]) === true) {
                     $fixes[$visibility] = 'final ' . $fixes[$visibility];
                 } else {
@@ -100,7 +100,7 @@ class MethodDeclarationSniff extends AbstractScopeSniff
             $fix = $phpcsFile->addFixableError($error, $abstract, 'AbstractAfterVisibility');
             if ($fix === true) {
                 $fixes[$abstract] = '';
-                $fixes[($abstract + 1)] = '';
+                $fixes[$abstract + 1] = '';
                 if (isset($fixes[$visibility]) === true) {
                     $fixes[$visibility] = 'abstract ' . $fixes[$visibility];
                 } else {
@@ -114,7 +114,7 @@ class MethodDeclarationSniff extends AbstractScopeSniff
             $fix = $phpcsFile->addFixableError($error, $static, 'StaticBeforeVisibility');
             if ($fix === true) {
                 $fixes[$static] = '';
-                $fixes[($static + 1)] = '';
+                $fixes[$static + 1] = '';
                 if (isset($fixes[$visibility]) === true) {
                     $fixes[$visibility] = $fixes[$visibility] . ' static';
                 } else {

--- a/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -163,7 +163,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            if ($tokens[($index + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+            if ($tokens[$index + 2]['code'] !== T_DOC_COMMENT_STRING) {
                 $throwTags[] = [
                     'index' => $index,
                     'fullClass' => null,
@@ -173,7 +173,7 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            $classAndAppendix = $tokens[($index + 2)]['content'];
+            $classAndAppendix = $tokens[$index + 2]['content'];
 
             $fullClass = $classAndAppendix;
             $appendix = '';

--- a/Spryker/Sniffs/Commenting/DocCommentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocCommentSniff.php
@@ -88,12 +88,12 @@ class DocCommentSniff extends AbstractSprykerSniff
         }
 
         // Check for additional blank lines at the end of the comment.
-        if ($tokens[$prev]['line'] < ($tokens[$commentEnd]['line'] - 1)) {
+        if ($tokens[$prev]['line'] < $tokens[$commentEnd]['line'] - 1) {
             $error = 'Additional blank lines found at end of doc comment';
             $fix = $phpcsFile->addFixableError($error, $commentEnd, 'SpacingAfter');
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
-                for ($i = ($prev + 1); $i < $commentEnd; $i++) {
+                for ($i = $prev + 1; $i < $commentEnd; $i++) {
                     if ($tokens[$i + 1]['line'] === $tokens[$commentEnd]['line']) {
                         break;
                     }
@@ -106,7 +106,7 @@ class DocCommentSniff extends AbstractSprykerSniff
         }
 
         // No extra newline before short description.
-        if ($tokens[$short]['line'] !== ($tokens[$stackPtr]['line'] + 1)) {
+        if ($tokens[$short]['line'] !== $tokens[$stackPtr]['line'] + 1) {
             $error = 'Doc comment short description must be on the first line';
             $fix = $phpcsFile->addFixableError($error, $short, 'SpacingBeforeShort');
             if ($fix === true) {
@@ -130,9 +130,9 @@ class DocCommentSniff extends AbstractSprykerSniff
         // multiple lines.
         $shortContent = $tokens[$short]['content'];
         $shortEnd = $short;
-        for ($i = ($short + 1); $i < $commentEnd; $i++) {
+        for ($i = $short + 1; $i < $commentEnd; $i++) {
             if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                if ($tokens[$i]['line'] === ($tokens[$shortEnd]['line'] + 1)) {
+                if ($tokens[$i]['line'] === $tokens[$shortEnd]['line'] + 1) {
                     $shortContent .= $tokens[$i]['content'];
                     $shortEnd = $i;
                 } else {
@@ -156,12 +156,12 @@ class DocCommentSniff extends AbstractSprykerSniff
             return;
         }
 
-        if ($tokens[$firstTag]['line'] !== ($tokens[$prev]['line'] + 2)) {
+        if ($tokens[$firstTag]['line'] !== $tokens[$prev]['line'] + 2) {
             $error = 'There must be exactly one blank line before the tags in a doc comment';
             $fix = $phpcsFile->addFixableError($error, $firstTag, 'SpacingBeforeTags');
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
-                for ($i = ($prev + 1); $i < $firstTag; $i++) {
+                for ($i = $prev + 1; $i < $firstTag; $i++) {
                     if ($tokens[$i]['line'] === $tokens[$firstTag]['line']) {
                         break;
                     }

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -123,7 +123,7 @@ class FileDocBlockSniff extends AbstractSprykerSniff
      */
     protected function isIgnorableModule(File $phpCsFile): bool
     {
-        return (in_array($this->getModule($phpCsFile), $this->ignorableModules, true));
+        return in_array($this->getModule($phpCsFile), $this->ignorableModules, true);
     }
 
     /**

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -250,7 +250,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
             true,
         );
 
-        $namespace = trim($phpCsFile->getTokensAsString(($namespaceStart), ($namespaceEnd - $namespaceStart)));
+        $namespace = trim($phpCsFile->getTokensAsString($namespaceStart, $namespaceEnd - $namespaceStart));
 
         return $namespace;
     }

--- a/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ConditionalExpressionOrderSniff.php
@@ -34,12 +34,12 @@ class ConditionalExpressionOrderSniff implements Sniff
     {
         $tokens = $phpCsFile->getTokens();
 
-        $prevIndex = $phpCsFile->findPrevious(Tokens::$emptyTokens, ($stackPointer - 1), null, true);
+        $prevIndex = $phpCsFile->findPrevious(Tokens::$emptyTokens, $stackPointer - 1, null, true);
         if (!in_array($tokens[$prevIndex]['code'], [T_TRUE, T_FALSE, T_NULL, T_LNUMBER, T_CONSTANT_ENCAPSED_STRING])) {
             return;
         }
 
-        $prevIndex = $phpCsFile->findPrevious(Tokens::$emptyTokens, ($prevIndex - 1), null, true);
+        $prevIndex = $phpCsFile->findPrevious(Tokens::$emptyTokens, $prevIndex - 1, null, true);
         if (!$prevIndex) {
             return;
         }

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -47,14 +47,14 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $openingBraceIndex = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openingBraceIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if (!$openingBraceIndex) {
             return;
         }
 
         $closingBraceIndex = $tokens[$openingBraceIndex]['parenthesis_closer'];
 
-        $valueIndex = $phpcsFile->findNext(Tokens::$emptyTokens, ($openingBraceIndex + 1), $closingBraceIndex, true);
+        $valueIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $openingBraceIndex + 1, $closingBraceIndex, true);
         if (!$valueIndex) {
             return;
         }
@@ -63,7 +63,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
             return;
         }
 
-        $lastValueIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closingBraceIndex - 1), $valueIndex, true) ?: $valueIndex;
+        $lastValueIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $closingBraceIndex - 1, $valueIndex, true) ?: $valueIndex;
 
         $validSilencing = $this->isValidSilencing($phpcsFile, $valueIndex, $lastValueIndex);
 
@@ -72,7 +72,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         }
 
         $inverted = false;
-        $previousTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $previousTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
         if (!$previousTokenIndex) {
             return;
         }
@@ -89,7 +89,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
             return;
         }
 
-        $nextTokenIndex = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingBraceIndex + 1), null, true);
+        $nextTokenIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $closingBraceIndex + 1, null, true);
         if ($nextTokenIndex && in_array($tokens[$nextTokenIndex]['code'], Tokens::$equalityTokens, true)) {
             $phpcsFile->addError($message, $stackPtr, 'InvalidEmpty');
 
@@ -141,7 +141,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
      */
     protected function isSafeToSkipCast(File $phpcsFile, int $stackPtr, int $previousTokenIndex): bool
     {
-        $assignmentTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousTokenIndex - 1), null, true);
+        $assignmentTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $previousTokenIndex - 1, null, true);
 
         $tokens = $phpcsFile->getTokens();
         if ($assignmentTokenIndex && in_array($tokens[$assignmentTokenIndex]['code'], [T_EQUAL, T_RETURN], true)) {
@@ -158,7 +158,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         /** @var int $index */
         $index = array_shift($keys);
 
-        $conditionalTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($index - 1), null, true);
+        $conditionalTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $index - 1, null, true);
         if (!$conditionalTokenIndex || !in_array($tokens[$conditionalTokenIndex]['code'], [T_IF, T_ELSEIF], true)) {
             return false;
         }
@@ -196,7 +196,7 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
             return false;
         }
 
-        $prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($objectOperatorIndex - 1), $valueIndex, true);
+        $prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $objectOperatorIndex - 1, $valueIndex, true);
         if ($prevIndex && $tokens[$prevIndex]['code'] === T_VARIABLE && $tokens[$prevIndex]['content'] !== '$this') {
             return true;
         }

--- a/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
+++ b/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
@@ -37,7 +37,7 @@ class NoInlineAssignmentSniff extends AbstractSprykerSniff
             return;
         }
 
-        $openingBraceIndex = (int)$phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openingBraceIndex = (int)$phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if (!$openingBraceIndex) {
             return;
         }
@@ -113,7 +113,7 @@ class NoInlineAssignmentSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $openingBraceIndex = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), $stackPtr + 4);
+        $openingBraceIndex = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1, $stackPtr + 4);
         if (!$openingBraceIndex) {
             return;
         }

--- a/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
+++ b/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
@@ -45,7 +45,7 @@ class ArrayDeclarationSniff implements Sniff
         $arrayEnd = $tokens[$stackPtr]['bracket_closer'];
 
         // Check for empty arrays.
-        $content = $phpcsFile->findNext(T_WHITESPACE, ($arrayStart + 1), ($arrayEnd + 1), true);
+        $content = $phpcsFile->findNext(T_WHITESPACE, $arrayStart + 1, $arrayEnd + 1, true);
         if ($content === $arrayEnd) {
             return;
         }
@@ -73,7 +73,7 @@ class ArrayDeclarationSniff implements Sniff
         // Check if there are multiple values. If so, then it has to be multiple lines
         // unless it is contained inside a function call or condition.
         $commas = [];
-        for ($i = ($arrayStart + 1); $i < $arrayEnd; $i++) {
+        for ($i = $arrayStart + 1; $i < $arrayEnd; $i++) {
             // Skip bracketed statements, like function calls.
             if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
                 $i = $tokens[$i]['parenthesis_closer'];
@@ -84,7 +84,7 @@ class ArrayDeclarationSniff implements Sniff
             if ($tokens[$i]['code'] === T_COMMA) {
                 // Before counting this comma, make sure we are not
                 // at the end of the array.
-                $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), $arrayEnd, true);
+                $next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, $arrayEnd, true);
                 if ($next !== false) {
                     $commas[] = $i;
                 } else {
@@ -130,7 +130,7 @@ class ArrayDeclarationSniff implements Sniff
         }
 
         // Find all the double arrows that reside in this scope.
-        for ($nextToken = ($stackPtr + 1); $nextToken < $arrayEnd; $nextToken++) {
+        for ($nextToken = $stackPtr + 1; $nextToken < $arrayEnd; $nextToken++) {
             // Skip bracketed statements, like function calls.
             if (
                 $tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS
@@ -150,7 +150,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 $parenthesisCloseIndex = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
-                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, ($parenthesisCloseIndex + 1), null, true);
+                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, $parenthesisCloseIndex + 1, null, true);
                 if (!$nextTokenIndex) {
                     break;
                 }
@@ -172,7 +172,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 $bracketCloseIndex = $tokens[$nextToken]['bracket_closer'];
-                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, ($bracketCloseIndex + 1), null, true);
+                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, $bracketCloseIndex + 1, null, true);
                 if (!$nextTokenIndex) {
                     break;
                 }
@@ -193,7 +193,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 $nextToken = $tokens[$nextToken]['scope_closer'];
-                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
+                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, $nextToken + 1, null, true);
                 if (!$nextTokenIndex) {
                     break;
                 }
@@ -245,7 +245,7 @@ class ArrayDeclarationSniff implements Sniff
                 if ($keyUsed === false) {
                     $valueContent = $phpcsFile->findNext(
                         Tokens::$emptyTokens,
-                        ($lastToken + 1),
+                        $lastToken + 1,
                         $nextToken,
                         true,
                     );
@@ -263,7 +263,7 @@ class ArrayDeclarationSniff implements Sniff
                 $keyUsed = true;
 
                 // Find the start of index that uses this double arrow.
-                $indexEnd = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($nextToken - 1), $arrayStart, true);
+                $indexEnd = (int)$phpcsFile->findPrevious(T_WHITESPACE, $nextToken - 1, $arrayStart, true);
                 $indexStart = $phpcsFile->findStartOfStatement($indexEnd);
 
                 if ($indexStart === $indexEnd) {
@@ -282,7 +282,7 @@ class ArrayDeclarationSniff implements Sniff
                 // Find the value of this index.
                 $nextContent = $phpcsFile->findNext(
                     Tokens::$emptyTokens,
-                    ($nextToken + 1),
+                    $nextToken + 1,
                     $arrayEnd,
                     true,
                 );

--- a/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
@@ -110,12 +110,12 @@ class SprykerDisallowFunctionsSniff extends AbstractSprykerSniff
             return;
         }
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens, true)) {
             return;
         }
 
-        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }

--- a/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/FunctionNamespaceSniff.php
@@ -32,24 +32,24 @@ class FunctionNamespaceSniff implements Sniff
 
         $tokenContent = $tokens[$stackPtr]['content'];
 
-        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }
 
-        $separatorIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $separatorIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$separatorIndex || $tokens[$separatorIndex]['type'] !== 'T_NS_SEPARATOR') {
             return;
         }
 
         // We check that this is a function but not new operator
-        $newIndex = $phpcsFile->findPrevious([T_WHITESPACE, T_NS_SEPARATOR], ($stackPtr - 1), null, true);
+        $newIndex = $phpcsFile->findPrevious([T_WHITESPACE, T_NS_SEPARATOR], $stackPtr - 1, null, true);
         if (!$newIndex || in_array($tokens[$newIndex]['code'], [T_NEW, T_ATTRIBUTE], true)) {
             return;
         }
 
         // We skip for non trivial cases
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($separatorIndex - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $separatorIndex - 1, null, true);
         if (!$previous || $tokens[$previous]['type'] === 'T_STRING') {
             return;
         }

--- a/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
@@ -58,12 +58,12 @@ class DisallowFunctionsSniff implements Sniff
             return;
         }
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens)) {
             return;
         }
 
-        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }
@@ -88,12 +88,12 @@ class DisallowFunctionsSniff implements Sniff
             return;
         }
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens)) {
             return;
         }
 
-        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }

--- a/Spryker/Sniffs/PHP/ExitSniff.php
+++ b/Spryker/Sniffs/PHP/ExitSniff.php
@@ -58,7 +58,7 @@ class ExitSniff implements Sniff
             $this->fixAlias($phpcsFile, $stackPtr, $key);
         }
 
-        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }

--- a/Spryker/Sniffs/PHP/NoIsNullSniff.php
+++ b/Spryker/Sniffs/PHP/NoIsNullSniff.php
@@ -38,12 +38,12 @@ class NoIsNullSniff extends AbstractSprykerSniff
             return;
         }
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
             return;
         }
 
-        $openingBraceIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBraceIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBraceIndex || $tokens[$openingBraceIndex]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }
@@ -52,7 +52,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
 
         $error = $tokenContent . '() found, should be strict === null check.';
 
-        $possibleCastIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $possibleCastIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
 
         if (!$possibleCastIndex) {
             return;
@@ -64,7 +64,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
         }
         // We dont want to fix double !!
         if ($negated) {
-            $anotherPossibleCastIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($possibleCastIndex - 1), null, true);
+            $anotherPossibleCastIndex = $phpcsFile->findPrevious(T_WHITESPACE, $possibleCastIndex - 1, null, true);
             if ($tokens[$anotherPossibleCastIndex]['code'] === T_BOOLEAN_NOT) {
                 $phpcsFile->addError($error, $stackPtr, 'DoubleNot');
 
@@ -154,7 +154,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($index - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $index - 1, null, true);
         if (!$previous) {
             return false;
         }
@@ -189,12 +189,12 @@ class NoIsNullSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($index - 1), null, true);
+        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, $index - 1, null, true);
         if (!$previous || !in_array($tokens[$previous]['code'], [T_IS_IDENTICAL, T_IS_NOT_IDENTICAL])) {
             return null;
         }
 
-        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($previous - 1), null, true);
+        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, $previous - 1, null, true);
         if (!$previous || !in_array($tokens[$previous]['code'], [T_TRUE, T_FALSE])) {
             return null;
         }
@@ -212,12 +212,12 @@ class NoIsNullSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $next = (int)$phpcsFile->findNext(T_WHITESPACE, ($index + 1), null, true);
+        $next = (int)$phpcsFile->findNext(T_WHITESPACE, $index + 1, null, true);
         if (!$next || !in_array($tokens[$next]['code'], [T_IS_IDENTICAL, T_IS_NOT_IDENTICAL])) {
             return null;
         }
 
-        $next = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($next - 1), null, true);
+        $next = (int)$phpcsFile->findPrevious(T_WHITESPACE, $next - 1, null, true);
         if (!$next || !in_array($tokens[$next]['code'], [T_TRUE, T_FALSE])) {
             return null;
         }
@@ -233,7 +233,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
      */
     protected function hasLeadingComparison(File $phpcsFile, int $stackPtr): bool
     {
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
 
         if (!$previous) {
             return false;
@@ -250,7 +250,7 @@ class NoIsNullSniff extends AbstractSprykerSniff
      */
     protected function hasTrailingComparison(File $phpcsFile, int $stackPtr): bool
     {
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
 
         if (!$next) {
             return false;

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -42,17 +42,17 @@ class PhpSapiConstantSniff implements Sniff
             return;
         }
 
-        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
             return;
         }
 
-        $openingBrace = (int)$phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = (int)$phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }
 
-        $closingBrace = (int)$phpcsFile->findNext(T_WHITESPACE, ($openingBrace + 1), null, true);
+        $closingBrace = (int)$phpcsFile->findNext(T_WHITESPACE, $openingBrace + 1, null, true);
         if (!$closingBrace || $tokens[$closingBrace]['type'] !== 'T_CLOSE_PARENTHESIS') {
             return;
         }

--- a/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
+++ b/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
@@ -48,12 +48,12 @@ class PreferCastOverFunctionSniff extends AbstractSprykerSniff
             return;
         }
 
-        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = (int)$phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
             return;
         }
 
-        $openingBraceIndex = (int)$phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBraceIndex = (int)$phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBraceIndex || $tokens[$openingBraceIndex]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }

--- a/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -71,12 +71,12 @@ class RemoveFunctionAliasSniff implements Sniff
             return;
         }
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
             return;
         }
 
-        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $openingBrace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$openingBrace || $tokens[$openingBrace]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }

--- a/Spryker/Sniffs/PHP/ShortCastSniff.php
+++ b/Spryker/Sniffs/PHP/ShortCastSniff.php
@@ -39,7 +39,7 @@ class ShortCastSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr]['content'] === '!') {
-            $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+            $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
             if (!$prevIndex || $tokens[$prevIndex]['content'] !== '!') {
                 return;
             }

--- a/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
+++ b/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
@@ -84,12 +84,12 @@ class AssertPrimitivesSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            $openingBraceIndex = $phpcsFile->findNext(T_WHITESPACE, ($i + 3), null, true);
+            $openingBraceIndex = $phpcsFile->findNext(T_WHITESPACE, $i + 3, null, true);
             if (!$openingBraceIndex) {
                 continue;
             }
 
-            $nextIndex = $phpcsFile->findNext(T_WHITESPACE, ($openingBraceIndex + 1), null, true);
+            $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $openingBraceIndex + 1, null, true);
             if (!$nextIndex || !in_array($tokens[$nextIndex]['content'], static::$primitives, true)) {
                 continue;
             }
@@ -101,10 +101,10 @@ class AssertPrimitivesSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            $commaIndex = $phpcsFile->findNext(T_WHITESPACE, ($nextIndex + 1), null, true);
+            $commaIndex = $phpcsFile->findNext(T_WHITESPACE, $nextIndex + 1, null, true);
             $nextParamIndex = null;
             if ($commaIndex && $tokens[$commaIndex]['code'] === T_COMMA) {
-                $nextParamIndex = $phpcsFile->findNext(T_WHITESPACE, ($commaIndex + 1), null, true);
+                $nextParamIndex = $phpcsFile->findNext(T_WHITESPACE, $commaIndex + 1, null, true);
             }
 
             $phpcsFile->fixer->beginChangeset();

--- a/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -33,13 +33,13 @@ class CommaSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if (!$next) {
             return;
         }
         $this->checkNext($phpcsFile, $stackPtr, $next);
 
-        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$previous) {
             return;
         }

--- a/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
@@ -41,9 +41,9 @@ class ConcatenationSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
 
-        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
+        if ($tokens[$stackPtr - 1]['code'] !== T_WHITESPACE) {
             $message = 'Expected 1 space before ., but 0 found';
             $fix = $phpcsFile->addFixableError($message, $stackPtr, 'MissingBefore');
             if ($fix) {
@@ -61,16 +61,16 @@ class ConcatenationSpacingSniff implements Sniff
             }
         }
 
-        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
 
-        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+        if ($tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
             $message = 'Expected 1 space after ., but 0 found';
             $fix = $phpcsFile->addFixableError($message, $stackPtr, 'MissingAfter');
             if ($fix) {
                 $this->addSpace($phpcsFile, $stackPtr);
             }
         } else {
-            $content = $tokens[($stackPtr + 1)]['content'];
+            $content = $tokens[$stackPtr + 1]['content'];
             if ($tokens[$nextIndex]['line'] === $tokens[$stackPtr]['line'] && $content !== ' ') {
                 $message = 'Expected 1 space after `.`, but %d found';
                 $data = [strlen($content)];

--- a/Spryker/Sniffs/WhiteSpace/DocBlockSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/DocBlockSpacingSniff.php
@@ -38,7 +38,7 @@ class DocBlockSpacingSniff implements Sniff
         while (!empty($tokens[$beginningOfLine - 1]) && $tokens[$beginningOfLine - 1]['line'] === $line) {
             $beginningOfLine--;
         }
-        $previousIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($beginningOfLine - 1), null, true);
+        $previousIndex = $phpcsFile->findPrevious(T_WHITESPACE, $beginningOfLine - 1, null, true);
 
         if (!$previousIndex || $tokens[$previousIndex]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
             return;

--- a/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
@@ -42,7 +42,7 @@ class EmptyEnclosingLineSniff extends AbstractSprykerSniff
         $curlyBraceStartIndex = $tokens[$stackPtr]['scope_opener'];
         $curlyBraceEndIndex = $tokens[$stackPtr]['scope_closer'];
 
-        $lastContentIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($curlyBraceEndIndex - 1), $stackPtr, true);
+        $lastContentIndex = $phpcsFile->findPrevious(T_WHITESPACE, $curlyBraceEndIndex - 1, $stackPtr, true);
         if (!$lastContentIndex) {
             return;
         }
@@ -71,7 +71,7 @@ class EmptyEnclosingLineSniff extends AbstractSprykerSniff
             return;
         }
 
-        $firstContentIndex = $phpcsFile->findNext(T_WHITESPACE, ($curlyBraceStartIndex + 1), $lastContentIndex, true);
+        $firstContentIndex = $phpcsFile->findNext(T_WHITESPACE, $curlyBraceStartIndex + 1, $lastContentIndex, true);
         if (!$firstContentIndex) {
             return;
         }

--- a/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -55,13 +55,13 @@ class EmptyLinesSniff extends AbstractSprykerSniff
 
         if (
             $tokens[$stackPtr]['content'] === $phpcsFile->eolChar
-            && isset($tokens[($stackPtr + 1)])
-            && $tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar
-            && isset($tokens[($stackPtr + 2)])
-            && $tokens[($stackPtr + 2)]['content'] === $phpcsFile->eolChar
+            && isset($tokens[$stackPtr + 1])
+            && $tokens[$stackPtr + 1]['content'] === $phpcsFile->eolChar
+            && isset($tokens[$stackPtr + 2])
+            && $tokens[$stackPtr + 2]['content'] === $phpcsFile->eolChar
         ) {
             $error = 'Found more than a single empty line between content';
-            $fix = $phpcsFile->addFixableError($error, ($stackPtr + 2), 'EmptyLines');
+            $fix = $phpcsFile->addFixableError($error, $stackPtr + 2, 'EmptyLines');
             if ($fix) {
                 $phpcsFile->fixer->replaceToken($stackPtr + 2, '');
             }

--- a/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -37,7 +37,7 @@ class ImplicitCastSpacingSniff implements Sniff
             return;
         }
 
-        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
 
         if ($nextIndex - $stackPtr === 1) {
             return;
@@ -61,7 +61,7 @@ class ImplicitCastSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if ($tokens[$nextIndex]['code'] === T_VARIABLE) {
             if ($nextIndex - $stackPtr === 1) {
                 return;
@@ -77,7 +77,7 @@ class ImplicitCastSpacingSniff implements Sniff
             return;
         }
 
-        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if ($tokens[$prevIndex]['code'] === T_VARIABLE) {
             if ($stackPtr - $prevIndex === 1) {
                 return;

--- a/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
@@ -33,12 +33,12 @@ class MethodSpacingSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $stringIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $stringIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if ($tokens[$stringIndex]['code'] !== T_STRING) {
             return;
         }
 
-        $parenthesisIndex = $phpcsFile->findNext(T_WHITESPACE, ($stringIndex + 1), null, true);
+        $parenthesisIndex = $phpcsFile->findNext(T_WHITESPACE, $stringIndex + 1, null, true);
         if ($tokens[$parenthesisIndex]['type'] !== 'T_OPEN_PARENTHESIS') {
             return;
         }
@@ -53,7 +53,7 @@ class MethodSpacingSniff extends AbstractSprykerSniff
 
         $parenthesisEndIndex = $tokens[$parenthesisIndex]['parenthesis_closer'];
 
-        $braceStartIndex = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET], ($parenthesisEndIndex + 1));
+        $braceStartIndex = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $parenthesisEndIndex + 1);
         if (!$braceStartIndex || $tokens[$braceStartIndex]['code'] !== T_OPEN_CURLY_BRACKET) {
             return;
         }
@@ -63,7 +63,7 @@ class MethodSpacingSniff extends AbstractSprykerSniff
         }
 
         $braceEndIndex = $tokens[$braceStartIndex]['bracket_closer'];
-        $nextContentIndex = $phpcsFile->findNext(T_WHITESPACE, ($braceStartIndex + 1), null, true);
+        $nextContentIndex = $phpcsFile->findNext(T_WHITESPACE, $braceStartIndex + 1, null, true);
         if (!$nextContentIndex) {
             return;
         }

--- a/Spryker/Sniffs/WhiteSpace/NamespaceSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/NamespaceSpacingSniff.php
@@ -33,7 +33,7 @@ class NamespaceSpacingSniff extends AbstractSprykerSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $beforeIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $beforeIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if (!$beforeIndex) {
             return;
         }

--- a/Spryker/Sniffs/WhiteSpace/ObjectAttributeSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ObjectAttributeSpacingSniff.php
@@ -34,7 +34,7 @@ class ObjectAttributeSpacingSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Make sure there is no space before.
-        $previousToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $previousToken = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
 
         if ($stackPtr - $previousToken !== 1 && $tokens[$previousToken]['line'] === $tokens[$stackPtr]['line']) {
             $error = 'Expected no space before object operator `' . $tokens[$stackPtr]['content'] . '`';
@@ -45,7 +45,7 @@ class ObjectAttributeSpacingSniff implements Sniff
         }
 
         // Make sure there is no space after.
-        $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
 
         if ($nextToken - $stackPtr !== 1 && $tokens[$nextToken]['line'] === $tokens[$stackPtr]['line']) {
             $error = 'Expected no space after object operator `' . $tokens[$stackPtr]['content'] . '`';

--- a/Spryker/Traits/NamespaceTrait.php
+++ b/Spryker/Traits/NamespaceTrait.php
@@ -27,7 +27,7 @@ trait NamespaceTrait
         $tokens = $phpcsFile->getTokens();
 
         // Ignore USE keywords inside closures.
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
         if ($tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             return true;
         }

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -77,6 +77,12 @@
 
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
 
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses">
+        <properties>
+            <property name="ignoreComplexTernaryConditions" value="true"/>
+        </properties>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>


### PR DESCRIPTION
Resolves https://github.com/spryker/code-sniffer/issues/309

WIP

Removes simple cases, but keeps e.g.

    return ($value === null || $value === '') ? 'NULL' : $value;

It allows other sniffs to work more correctly, e.g. the following is a result then as well:
```diff
Index: src/Pyz/Zed/DataImport/Business/Model/ProductSearchAttributeMap/ProductSearchAttributeMapWriter.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/Pyz/Zed/DataImport/Business/Model/ProductSearchAttributeMap/ProductSearchAttributeMapWriter.php b/src/Pyz/Zed/DataImport/Business/Model/ProductSearchAttributeMap/ProductSearchAttributeMapWriter.php
--- a/src/Pyz/Zed/DataImport/Business/Model/ProductSearchAttributeMap/ProductSearchAttributeMapWriter.php	(revision 34288fd809c1a91c138850b3c97bc155d4059ce1)
+++ b/src/Pyz/Zed/DataImport/Business/Model/ProductSearchAttributeMap/ProductSearchAttributeMapWriter.php	(date 1640706021702)
@@ -59,7 +59,7 @@
             ->filterByTargetField($targetKey)
             ->findOneOrCreate();
 
-        $productSearchAttributeMapEntity->setSynced((isset($dataSet[static::KEY_SYNCED])) ? $dataSet[static::KEY_SYNCED] : true);
+        $productSearchAttributeMapEntity->setSynced($dataSet[static::KEY_SYNCED] ?? true);
         $productSearchAttributeMapEntity->save();
     }
 }
Index: src/Pyz/Zed/DataImport/Business/Model/Product/Repository/ProductRepository.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/Pyz/Zed/DataImport/Business/Model/Product/Repository/ProductRepository.php b/src/Pyz/Zed/DataImport/Business/Model/Product/Repository/ProductRepository.php
--- a/src/Pyz/Zed/DataImport/Business/Model/Product/Repository/ProductRepository.php	(revision 34288fd809c1a91c138850b3c97bc155d4059ce1)
+++ b/src/Pyz/Zed/DataImport/Business/Model/Product/Repository/ProductRepository.php	(date 1640706021882)
@@ -182,7 +182,7 @@
     {
         static::$resolved[$productEntity->getSku()] = [
             static::ID_PRODUCT => $productEntity->getIdProduct(),
-            static::ABSTRACT_SKU => ($abstractSku) ? $abstractSku : $productEntity->getSpyProductAbstract()->getSku(),
+            static::ABSTRACT_SKU => $abstractSku ?: $productEntity->getSpyProductAbstract()->getSku(),
         ];
     }
```