### PR TITLE
TE-10552 Using generics for all collections including all objects

### DIFF
--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -27,7 +27,7 @@ use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Helpers\TypeHintHelper;
 
 /**
- * Fixed version of Slevomatic, not touching collection objects.
+ * Fixed version of Slevomatic, touching collection objects the right way.
  *
  * @see https://github.com/slevomat/coding-standard/issues/1296
  */
@@ -42,20 +42,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
      * @var array<string>
      */
     public $traversableTypeHints = [];
-
-    /**
-     * The following classes are supported for object generics by IDEs like PHPStorm already.
-     * E.g. `\ArrayObject<type>` instead of legacy syntax `\ArrayObject|type[]`.
-     *
-     * @var array<string>
-     */
-    protected static $genericCollectionClasses = [
-        '\\Traversable',
-        '\\ArrayAccess',
-        '\\ArrayObject',
-        '\\Generator',
-        '\\Iterator',
-    ];
 
     /**
      * @var array<string, int>|null
@@ -90,6 +76,8 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                 }
 
                 if ($this->isGenericObjectCollection($annotation)) {
+                    $this->fixGenericObjectCollection($phpcsFile, $docCommentOpenPointer, $annotation);
+
                     continue;
                 }
 
@@ -374,5 +362,33 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         }
 
         return false;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $docCommentOpenPointer
+     * @param \SlevomatCodingStandard\Helpers\Annotation\GenericAnnotation $annotation
+     *
+     * @return void
+     */
+    protected function fixGenericObjectCollection(File $phpcsFile, int $docCommentOpenPointer, Annotation $annotation): void
+    {
+        foreach (AnnotationHelper::getAnnotationTypes($annotation) as $annotationType) {
+            /*
+            if ($annotationType instanceof UnionTypeNode) {
+                if (
+                    !$this->hasGenericObject($annotationType->types)
+                    || !$this->containsArrayTypeNode($annotationType->types)
+                ) {
+                    return;
+                }
+                */
+
+            //TODO
+            $genericIdentifier = $this->findGenericIdentifier($phpcsFile, $annotationType, $annotation);
+            if ($genericIdentifier) {
+                var_dump($genericIdentifier);die();
+            }
+        }
     }
 }

--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -426,7 +426,9 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                 if ($arrayType !== null) {
                     return;
                 }
-                $arrayType = $this->convertTypeToString($type->type);
+                /** @var \PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode $arrayTypeNode */
+                $arrayTypeNode = $type;
+                $arrayType = $this->convertTypeToString($arrayTypeNode->type);
 
                 continue;
             }

--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -9,7 +9,6 @@ namespace Spryker\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -19,7 +18,6 @@ use SlevomatCodingStandard\Helpers\Annotation\Annotation;
 use SlevomatCodingStandard\Helpers\Annotation\GenericAnnotation;
 use SlevomatCodingStandard\Helpers\Annotation\ParameterAnnotation;
 use SlevomatCodingStandard\Helpers\Annotation\ReturnAnnotation;
-use SlevomatCodingStandard\Helpers\Annotation\VariableAnnotation;
 use SlevomatCodingStandard\Helpers\AnnotationHelper;
 use SlevomatCodingStandard\Helpers\AnnotationTypeHelper;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
@@ -403,7 +401,7 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param \SlevomatCodingStandard\Helpers\Annotation\Annotation $annotation
+     * @param \SlevomatCodingStandard\Helpers\Annotation\VariableAnnotation|\SlevomatCodingStandard\Helpers\Annotation\ParameterAnnotation|\SlevomatCodingStandard\Helpers\Annotation\ReturnAnnotation|\SlevomatCodingStandard\Helpers\Annotation\ThrowsAnnotation|\SlevomatCodingStandard\Helpers\Annotation\PropertyAnnotation|\SlevomatCodingStandard\Helpers\Annotation\MethodAnnotation|\SlevomatCodingStandard\Helpers\Annotation\TemplateAnnotation|\SlevomatCodingStandard\Helpers\Annotation\ExtendsAnnotation|\SlevomatCodingStandard\Helpers\Annotation\ImplementsAnnotation|\SlevomatCodingStandard\Helpers\Annotation\UseAnnotation|\SlevomatCodingStandard\Helpers\Annotation\MixinAnnotation|\SlevomatCodingStandard\Helpers\Annotation\TypeAliasAnnotation|\SlevomatCodingStandard\Helpers\Annotation\TypeImportAnnotation $annotation
      *
      * @return void
      */
@@ -430,11 +428,10 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                 continue;
             }
 
-            if ($this->isArrayTypeNode($type)) {
+            if ($this->isArrayTypeNode($type) && $type instanceof ArrayTypeNode) {
                 if ($arrayType !== null) {
                     return;
                 }
-
                 $arrayType = $this->convertTypeToString($type->type);
 
                 continue;
@@ -470,9 +467,10 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
 
         $fixedType = implode('|', $unionTypes);
 
-        $spacePosition = strpos($annotation->getContent(), ' ');
+        $content = $annotation->getContent() ?? '';
+        $spacePosition = strpos($content, ' ');
         if ($spacePosition !== false) {
-            $fixedType .= substr($annotation->getContent(), $spacePosition);
+            $fixedType .= substr($content, $spacePosition);
         }
 
         $nextToken = $phpcsFile->fixer->getTokenContent($annotation->getEndPointer() + 1);
@@ -491,7 +489,7 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
      */
     protected function convertTypeToString(TypeNode $typeNode): string
     {
-        if ($this->isArrayTypeNode($typeNode)) {
+        if ($typeNode instanceof ArrayTypeNode) {
             return sprintf('array<%s>', $this->convertTypeToString($typeNode->type));
         }
 

--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -326,14 +326,8 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
      */
     protected function isUnionTypeGenericObjectCollection(UnionTypeNode $unionTypeNode): bool
     {
-        if (
-            $this->hasGenericObject($unionTypeNode->types)
-            && $this->containsArrayTypeNode($unionTypeNode->types)
-        ) {
-            return true;
-        }
-
-        return false;
+        return $this->hasGenericObject($unionTypeNode->types)
+            && $this->containsArrayTypeNode($unionTypeNode->types);
     }
 
     /**
@@ -428,7 +422,7 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                 continue;
             }
 
-            if ($this->isArrayTypeNode($type) && $type instanceof ArrayTypeNode) {
+            if ($this->isArrayTypeNode($type)) {
                 if ($arrayType !== null) {
                     return;
                 }
@@ -446,7 +440,7 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
 
         $fix = $phpcsFile->addFixableError(
             sprintf(
-                'Usage of old type hint syntax for generic in "%s" is disallowed, use generic type hint syntax instead.',
+                'Usage of old type hint syntax for generic in `%s` is disallowed, use generic type hint syntax instead.',
                 AnnotationTypeHelper::export($typeNode),
             ),
             $annotation->getStartPointer(),

--- a/Spryker/Sniffs/Commenting/TypeHintSniff.php
+++ b/Spryker/Sniffs/Commenting/TypeHintSniff.php
@@ -34,7 +34,6 @@ use Spryker\Traits\CommentingTrait;
 
 /**
  * Verifies order of types in type hints. Also removes duplicates.
- * Fixes invalid/problematic generic declarations back to legacy ones.
  */
 class TypeHintSniff extends AbstractSprykerSniff
 {
@@ -241,11 +240,10 @@ class TypeHintSniff extends AbstractSprykerSniff
 
     /**
      * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types node types
-     * @param string $tag
      *
      * @return string
      */
-    protected function getSortedTypeHint(array $types, string $tag): string
+    protected function getSortedTypeHint(array $types): string
     {
         $sortable = array_fill_keys(static::$sortMap, []);
         $unsortable = [];
@@ -253,10 +251,9 @@ class TypeHintSniff extends AbstractSprykerSniff
             $sortName = null;
             if ($type instanceof IdentifierTypeNode) {
                 $sortName = $type->name;
-                if (mb_substr($sortName, 0, 1) === '\\') {
+                if ($sortName[0] === '\\') {
                     $sortName = '_obj_' . $sortName;
                 }
-
             } elseif ($type instanceof NullableTypeNode) {
                 if ($type->type instanceof IdentifierTypeNode) {
                     $sortName = $type->type->name;
@@ -269,7 +266,10 @@ class TypeHintSniff extends AbstractSprykerSniff
                 } else {
                     $sortName = 'array';
                 }
-            } elseif ($type instanceof ArrayShapeNode) {
+            } elseif (
+                $type instanceof ArrayShapeNode ||
+                ($type instanceof GenericTypeNode && $type->type->name === 'array')
+            ) {
                 $sortName = 'array';
             }
 

--- a/Spryker/Sniffs/Commenting/TypeHintSniff.php
+++ b/Spryker/Sniffs/Commenting/TypeHintSniff.php
@@ -132,7 +132,7 @@ class TypeHintSniff extends AbstractSprykerSniff
             }
 
             $originalTypeHint = $this->renderUnionTypes($types);
-            $sortedTypeHint = $this->getSortedTypeHint($types, $tokens[$tag]['content']);
+            $sortedTypeHint = $this->getSortedTypeHint($types);
             if ($sortedTypeHint === $originalTypeHint) {
                 continue;
             }

--- a/tests/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniffTest.php
@@ -17,7 +17,7 @@ class DisallowArrayTypeHintSyntaxSniffTest extends TestCase
      */
     public function testDisallowArrayTypeHintSyntaxSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new DisallowArrayTypeHintSyntaxSniff(), 1);
+        $this->assertSnifferFindsErrors(new DisallowArrayTypeHintSyntaxSniff(), 12);
     }
 
     /**

--- a/tests/Spryker/Sniffs/Commenting/TypeHintSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/TypeHintSniffTest.php
@@ -17,7 +17,7 @@ class TypeHintSniffTest extends TestCase
      */
     public function testTypeHintSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new TypeHintSniff(), 12);
+        $this->assertSnifferFindsErrors(new TypeHintSniff(), 10);
     }
 
     /**

--- a/tests/_data/DisallowArrayTypeHintSyntax/after.php
+++ b/tests/_data/DisallowArrayTypeHintSyntax/after.php
@@ -9,15 +9,23 @@ class FixMe
      */
     protected function getSimpleInts(): array
     {
-        return $this>foo();
+        return $this->foo();
     }
 
     /**
-     * @return \Iterator|int[]
+     * @return \ArrayObject<string>
+     */
+    protected function getSimpleStringCollection()
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \Iterator<int>
      */
     protected function getSimpleIntCollection(): Iterator
     {
-        return $this>foo();
+        return $this->foo();
     }
 
     /**

--- a/tests/_data/DisallowArrayTypeHintSyntax/after.php
+++ b/tests/_data/DisallowArrayTypeHintSyntax/after.php
@@ -5,17 +5,55 @@ namespace Spryker;
 class FixMe
 {
     /**
+     * @var \ArrayObject<string>
+     */
+    protected $prop;
+
+    /**
+     * @var \ArrayObject<string> Some description.
+     */
+    protected $propWithDescription;
+
+    /**
+     * @param array<string> $var
+     *
      * @return array<int>
      */
-    protected function getSimpleInts(): array
+    protected function getSimpleInts(array $var): array
     {
         return $this->foo();
     }
 
     /**
+     * @param \ArrayObject<string> $var Some comment.
+     *
      * @return \ArrayObject<string>
      */
-    protected function getSimpleStringCollection()
+    protected function getSimpleStringCollection($var)
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject|array<string>
+     */
+    protected function getArrayObjectOrArray()
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject<string>|array<int>
+     */
+    protected function getArrayObjectOfStringsOrArrayOfInts()
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject<string>|null
+     */
+    protected function getSimpleStringCollectionOrNull(): ?\ArrayObject
     {
         return $this->foo();
     }
@@ -29,10 +67,24 @@ class FixMe
     }
 
     /**
-     * @return \Iterator|\Generated\Shared\Transfer\EventEntityTransfer[][]
+     * @return \Iterator<array<\Generated\Shared\Transfer\EventEntityTransfer>>
      */
     protected function createEventResourceQueryContainerPluginIterator(): Iterator
     {
         return new EventResourceQueryContainerPluginIterator();
+    }
+
+    /**
+     * @return void
+     */
+    protected function inlineDocBlock()
+    {
+        /** @var \ArrayObject<string> $bar */
+        $bar = $this->foo();
+
+        /**
+         * @var \ArrayObject<string> $bar
+         */
+        $bar = $this->foo();
     }
 }

--- a/tests/_data/DisallowArrayTypeHintSyntax/before.php
+++ b/tests/_data/DisallowArrayTypeHintSyntax/before.php
@@ -5,17 +5,55 @@ namespace Spryker;
 class FixMe
 {
     /**
+     * @var \ArrayObject|string[]
+     */
+    protected $prop;
+
+    /**
+     * @var \ArrayObject|string[] Some description.
+     */
+    protected $propWithDescription;
+
+    /**
+     * @param string[] $var
+     *
      * @return int[]
      */
-    protected function getSimpleInts(): array
+    protected function getSimpleInts(array $var): array
     {
         return $this->foo();
     }
 
     /**
+     * @param \ArrayObject|string[] $var Some comment.
+     *
      * @return \ArrayObject|string[]
      */
-    protected function getSimpleStringCollection()
+    protected function getSimpleStringCollection($var)
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject|array<string>
+     */
+    protected function getArrayObjectOrArray()
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject<string>|int[]
+     */
+    protected function getArrayObjectOfStringsOrArrayOfInts()
+    {
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject|string[]|null
+     */
+    protected function getSimpleStringCollectionOrNull(): ?\ArrayObject
     {
         return $this->foo();
     }
@@ -34,5 +72,19 @@ class FixMe
     protected function createEventResourceQueryContainerPluginIterator(): Iterator
     {
         return new EventResourceQueryContainerPluginIterator();
+    }
+
+    /**
+     * @return void
+     */
+    protected function inlineDocBlock()
+    {
+        /** @var \ArrayObject|string[] $bar */
+        $bar = $this->foo();
+
+        /**
+         * @var \ArrayObject|string[] $bar
+         */
+        $bar = $this->foo();
     }
 }

--- a/tests/_data/DisallowArrayTypeHintSyntax/before.php
+++ b/tests/_data/DisallowArrayTypeHintSyntax/before.php
@@ -9,7 +9,15 @@ class FixMe
      */
     protected function getSimpleInts(): array
     {
-        return $this>foo();
+        return $this->foo();
+    }
+
+    /**
+     * @return \ArrayObject|string[]
+     */
+    protected function getSimpleStringCollection()
+    {
+        return $this->foo();
     }
 
     /**
@@ -17,7 +25,7 @@ class FixMe
      */
     protected function getSimpleIntCollection(): Iterator
     {
-        return $this>foo();
+        return $this->foo();
     }
 
     /**

--- a/tests/_data/TypeHint/after.php
+++ b/tests/_data/TypeHint/after.php
@@ -69,9 +69,19 @@ class FixMe
     }
 
     /**
+     * @param \Propel\Runtime\Collection|array<int|string>|string|int $x
+     *
+     * @return \Propel\Runtime\Collection|\ArrayObject<\Foo>|array<int|string>|string|int
+     */
+    protected function sortMultiple($x)
+    {
+        return $x;
+    }
+
+    /**
      * @return \Generator<array<\Generated\Shared\Transfer\ProductAbstractTransfer>>
      */
-    public function getRelatedProducts(): Generator
+    public function mergeGenerics(): Generator
     {
         yield $this->x();
     }

--- a/tests/_data/TypeHint/after.php
+++ b/tests/_data/TypeHint/after.php
@@ -33,7 +33,7 @@ class FixMe
     }
 
     /**
-     * @param \ArrayObject|int[] $array
+     * @param \ArrayObject<int> $array
      *
      * @return \ArrayAccess|array<int> $array
      */
@@ -59,7 +59,7 @@ class FixMe
      */
     protected function complex($col)
     {
-        /** @var \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\SalesReturn\Persistence\SpySalesReturn[] $salesReturnEntityCollection */
+        /** @var \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\SalesReturn\Persistence\SpySalesReturn> $salesReturnEntityCollection */
         $salesReturnEntityCollection = $this->runQuery();
 
         /** @var \ArrayObject<\Generated\Shared\Transfer\ShipmentGroupTransfer> $shipmentGroupCollection */
@@ -74,6 +74,16 @@ class FixMe
     public function getRelatedProducts(): Generator
     {
         yield $this->x();
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductImage\Persistence\SpyProductImageSet> $productImageSetEntities
+     *
+     * @return array<\Generated\Shared\Transfer\ProductImageSetTransfer>
+     */
+    protected function complexGeneric(ObjectCollection $productImageSetEntities): array
+    {
+        return [];
     }
 
     /**

--- a/tests/_data/TypeHint/after.php
+++ b/tests/_data/TypeHint/after.php
@@ -33,7 +33,7 @@ class FixMe
     }
 
     /**
-     * @param \ArrayObject<int> $array
+     * @param \ArrayObject|int[] $array
      *
      * @return \ArrayAccess|array<int> $array
      */
@@ -45,7 +45,7 @@ class FixMe
     /**
      * @param \Collection|int[] $array
      *
-     * @return \Collection|int[] $array
+     * @return \Collection|array<int> $array
      */
     public function collection(array $array): array
     {
@@ -53,9 +53,9 @@ class FixMe
     }
 
     /**
-     * @param \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\Sales\Persistence\SpySalesShipment[] $col
+     * @param \Propel\Runtime\Collection\ObjectCollection|iterable<\Orm\Zed\Sales\Persistence\SpySalesShipment> $col
      *
-     * @return \Propel\Runtime\Collection\Collection|\Propel\Runtime\Collection\ObjectCollection|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]
+     * @return \Propel\Runtime\Collection\Collection|\Propel\Runtime\Collection\ObjectCollection<\Propel\Runtime\ActiveRecord\ActiveRecordInterface>
      */
     protected function complex($col)
     {

--- a/tests/_data/TypeHint/before.php
+++ b/tests/_data/TypeHint/before.php
@@ -80,6 +80,16 @@ class FixMe
     }
 
     /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductImage\Persistence\SpyProductImageSet> $productImageSetEntities
+     *
+     * @return array<\Generated\Shared\Transfer\ProductImageSetTransfer>
+     */
+    protected function complexGeneric(ObjectCollection $productImageSetEntities): array
+    {
+        return [];
+    }
+
+    /**
      * @phpstan-param \ArrayObject<string, mixed> $options
      * @phpstan-return array<string>
      *

--- a/tests/_data/TypeHint/before.php
+++ b/tests/_data/TypeHint/before.php
@@ -70,11 +70,21 @@ class FixMe
     }
 
     /**
+     * @param string|int|\Propel\Runtime\Collection|array<int|string> $x
+     *
+     * @return string|int|\Propel\Runtime\Collection|array<int|string>|\ArrayObject<\Foo>
+     */
+    protected function sortMultiple($x)
+    {
+        return $x;
+    }
+
+    /**
      * @phpstan-return \Generator<array<\Generated\Shared\Transfer\ProductAbstractTransfer>>
      *
      * @return \Generator<array<\Generated\Shared\Transfer\ProductAbstractTransfer>>
      */
-    public function getRelatedProducts(): Generator
+    public function mergeGenerics(): Generator
     {
         yield $this->x();
     }


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/TE-10552
RG: https://release.spryker.com/release-groups/view/4041

- [x] Adjusted `TypeHintSniff` so it fixes sorting and duplication in types in php docblocks.
- [x] Adjusted `DisallowArrayTypeHintSyntaxSniff` so it fixes legacy generic syntax. E.g. `@return \Iterator|int[]` -> `@return \Iterator<int>`.