### PR TITLE
Improve method annotation sniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,41 @@ want to use all the new language features:
 ```
 They ship with the core by default to avoid PHP8-creep into PHP7.4+ code.
 
+## Configure custom namespaces
+Certain sniffs rely on a list of namespaces, which defaults to `Pyz,SprykerEco,SprykerMiddleware,SprykerSdk,Spryker`, but can be customized like so:
+```xml
+    <rule ref="Spryker.MethodAnnotation.ConfigMethodAnnotation">
+        <properties>
+            <property name="namespaces" value="MyCustomPyz,SprykerEco,Spryker" />
+        </properties>
+    </rule>
+    <rule ref="Spryker.MethodAnnotation.EntityManagerMethodAnnotation">
+        <properties>
+            <property name="namespaces" value="MyCustomPyz,SprykerEco,Spryker" />
+        </properties>
+    </rule>
+    <rule ref="Spryker.MethodAnnotation.FacadeMethodAnnotation">
+        <properties>
+            <property name="namespaces" value="MyCustomPyz,SprykerEco,Spryker" />
+        </properties>
+    </rule>
+    <rule ref="Spryker.MethodAnnotation.FactoryMethodAnnotation">
+        <properties>
+            <property name="namespaces" value="MyCustomPyz,SprykerEco,Spryker" />
+        </properties>
+    </rule>
+    <rule ref="Spryker.MethodAnnotation.QueryContainerMethodAnnotation">
+        <properties>
+            <property name="namespaces" value="MyCustomPyz,SprykerEco,Spryker" />
+        </properties>
+    </rule>
+    <rule ref="Spryker.MethodAnnotation.RepositoryMethodAnnotation">
+        <properties>
+            <property name="namespaces" value="MyCustomPyz,SprykerEco,Spryker" />
+        </properties>
+    </rule>
+```
+
 ## Excluding test related comparison files
 If you want to exclude certain generated (e.g. PHP) files, make sure those are in a `test_files` subfolder to be auto-skipped.
 You can otherwise always create a custom and rather unique folder name and manually exclude it in your PHPCS settings.

--- a/Spryker/Sniffs/MethodAnnotation/ConfigMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/ConfigMethodAnnotationSniff.php
@@ -66,14 +66,16 @@ class ConfigMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param string $namespacePart
      *
      * @return string
      */
-    protected function getMethodAnnotationFileName(File $phpCsFile): string
+    protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
         $classNameParts = array_slice($classNameParts, 0, 3);
+        $classNameParts[0] = $namespacePart;
         array_push($classNameParts, $this->getMethodFileAddedName($phpCsFile));
 
         return '\\' . implode('\\', $classNameParts);

--- a/Spryker/Sniffs/MethodAnnotation/EntityManagerMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/EntityManagerMethodAnnotationSniff.php
@@ -54,14 +54,16 @@ class EntityManagerMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param string $namespacePart
      *
      * @return string
      */
-    protected function getMethodAnnotationFileName(File $phpCsFile): string
+    protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
         $classNameParts = array_slice($classNameParts, 0, 3);
+        $classNameParts[0] = $namespacePart;
         array_push($classNameParts, static::LAYER_PERSISTENCE);
         array_push($classNameParts, $this->getMethodFileAddedName($phpCsFile));
 

--- a/Spryker/Sniffs/MethodAnnotation/FacadeMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/FacadeMethodAnnotationSniff.php
@@ -70,14 +70,16 @@ class FacadeMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param string $namespacePart
      *
      * @return string
      */
-    protected function getMethodAnnotationFileName(File $phpCsFile): string
+    protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
         $classNameParts = array_slice($classNameParts, 0, 3);
+        $classNameParts[0] = $namespacePart;
         array_push($classNameParts, static::LAYER_BUSINESS);
         array_push($classNameParts, $this->getMethodFileAddedName($phpCsFile));
 

--- a/Spryker/Sniffs/MethodAnnotation/FactoryMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/FactoryMethodAnnotationSniff.php
@@ -82,14 +82,16 @@ class FactoryMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param string $namespacePart
      *
      * @return string
      */
-    protected function getMethodAnnotationFileName(File $phpCsFile): string
+    protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
         $classNameParts = array_slice($classNameParts, 0, 3);
+        $classNameParts[0] = $namespacePart;
         array_push($classNameParts, $this->getLayer($phpCsFile));
         array_push($classNameParts, $this->getMethodFileAddedName($phpCsFile));
 

--- a/Spryker/Sniffs/MethodAnnotation/QueryContainerMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/QueryContainerMethodAnnotationSniff.php
@@ -70,14 +70,16 @@ class QueryContainerMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param string $namespacePart
      *
      * @return string
      */
-    protected function getMethodAnnotationFileName(File $phpCsFile): string
+    protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
         $classNameParts = array_slice($classNameParts, 0, 3);
+        $classNameParts[0] = $namespacePart;
         array_push($classNameParts, static::LAYER_PERSISTENCE);
         array_push($classNameParts, $this->getMethodFileAddedName($phpCsFile));
 

--- a/Spryker/Sniffs/MethodAnnotation/RepositoryMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/RepositoryMethodAnnotationSniff.php
@@ -70,14 +70,16 @@ class RepositoryMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpCsFile
+     * @param string $namespacePart
      *
      * @return string
      */
-    protected function getMethodAnnotationFileName(File $phpCsFile): string
+    protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);
         $classNameParts = explode('\\', $className);
         $classNameParts = array_slice($classNameParts, 0, 3);
+        $classNameParts[0] = $namespacePart;
         array_push($classNameParts, static::LAYER_PERSISTENCE);
         array_push($classNameParts, $this->getMethodFileAddedName($phpCsFile));
 


### PR DESCRIPTION
## PR Description

I found some things in the Sniffs related to the `@method` annotations above classes and took some time to optimize that.

1. ~Running the fixer on a final class inserts the docblock in the wrong place as you can see [here](https://twitter.com/AlfredBez/status/1484154374679154690)~ -> see #322 
2. ~When checking if an annotation should be added or not, there is a check for the direct parent class. This does not take all parent classes into consideration. We regularly extend some Plugin from the `Spryker` namespace in our `Pyz` namespace and therefore do not extend the `AbstractPlugin`, but the `FooBarPlugin` class in the `Spryker` namespace, that extends the `AbstractPlugin` itself. I extended the check from the direct parent of a class, to check against all parent classes.~ -> see #321 
3. The magic `@method` annotations are not added, when you have a class in `Pyz`, but the magically resolved class (the `Config`, `Facade`, `EntityManager`, etc) is not extended in `Pyz` and therefore the version from the `Spryker` namespace is used. I fixed this behavior, by first checking for these classes in `Pyz` and after that also in the core namespaces.

I tried this out in our project and it resolved the annotations as expected, see for example:
```php
<?php

// ...

use Spryker\Zed\Oms\Business\OmsFacade as SprykerOmsFacade;

/**
 * @method \Pyz\Zed\Oms\Business\OmsBusinessFactory getFactory()
 * @method \Pyz\Zed\Oms\Persistence\OmsEntityManagerInterface getEntityManager()
 * @method \Pyz\Zed\Oms\Persistence\OmsQueryContainerInterface getQueryContainer()
 * @method \Spryker\Zed\Oms\Persistence\OmsRepositoryInterface getRepository()
 */
class OmsFacade extends SprykerOmsFacade implements

// ...
```

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
