### PR TITLE
Fix method annotation sniff when using final classes

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
@@ -207,6 +207,10 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         if ($abstractPosition) {
             return $abstractPosition;
         }
+        $finalPosition = (int)$phpCsFile->findPrevious(T_FINAL, $stackPointer);
+        if ($finalPosition) {
+            return $finalPosition;
+        }
 
         return $stackPointer;
     }


### PR DESCRIPTION
## PR Description

(From #320)
Running the fixer on a final class inserts the docblock in the wrong place as you can see [here](https://twitter.com/AlfredBez/status/1484154374679154690)

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
