### PR TITLE
Fix getParentClassesFor method return type

### DIFF
--- a/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
@@ -46,7 +46,7 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
      * @param \PHP_CodeSniffer\Files\File $file
      * @param int $stackPointer
      *
-     * @return array<class-string>
+     * @return array<string>
      */
     protected function getParentClassesFor(File $file, int $stackPointer): array
     {
@@ -70,11 +70,7 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
             if (!$parentClass instanceof ReflectionClass) {
                 break;
             }
-            $parentClassName = $parentClass->getShortName();
-            if (!class_exists($parentClassName)) {
-                break;
-            }
-            $parents[] = $parentClassName;
+            $parents[] = $parentClass->getShortName();
             $fullName = $parentClass->getName();
         } while ($parentClass);
 


### PR DESCRIPTION
## PR Description

It does not return real `class-string`s, because we're only checking against the actual class name without the namespace part

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
