### PR TITLE
Use PHPDoc license tag in *all* files

### DIFF
--- a/Spryker/Traits/CommentingTrait.php
+++ b/Spryker/Traits/CommentingTrait.php
@@ -1,8 +1,7 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * @license https://github.com/spryker/code-sniffer/blob/master/LICENSE MIT
  */
 
 namespace Spryker\Traits;


### PR DESCRIPTION
Please see https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/license.html

@dereuromark Is it okay with you?
