### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "framework",
         "codesniffer",
         "phpcs",
+        "static analysis",
         "standards"
     ],
     "homepage": "https://spryker.com",


### PR DESCRIPTION
## PR Description

As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md  
**(Can't check this, as I can't find the contributing file)**
