### PR TITLE
Add missing elseif case.

### DIFF
--- a/Spryker/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Usage of `else if` is not allowed, use `elseif` instead.
+ */
+class ElseIfDeclarationSniff implements Sniff
+{
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [
+            T_ELSE,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($tokens[$next]['code'] === T_IF) {
+            $phpcsFile->recordMetric($stackPtr, 'Use of ELSE IF or ELSEIF', 'else if');
+            $error = 'Usage of `else if` is not allowed, use `elseif` instead';
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NotAllowed');
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($stackPtr, 'elseif');
+                for ($i = ($stackPtr + 1); $i <= $next; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+    }
+}

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -133,6 +133,9 @@
     <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
         <severity>0</severity>
     </rule>
+    <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed">
+        <severity>0</severity>
+    </rule>
 
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 
 
-The SprykerStrict standard contains 235 sniffs
+The SprykerStrict standard contains 236 sniffs
 
 Generic (25 sniffs)
 -------------------
@@ -127,7 +127,7 @@ SlevomatCodingStandard (48 sniffs)
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 - SlevomatCodingStandard.Whitespaces.DuplicateSpaces
 
-Spryker (98 sniffs)
+Spryker (99 sniffs)
 -------------------
 - Spryker.Arrays.DisallowImplicitArrayCreation
 - Spryker.Classes.ClassFileName
@@ -177,6 +177,7 @@ Spryker (98 sniffs)
 - Spryker.ControlStructures.ConditionalExpressionOrder
 - Spryker.ControlStructures.ControlStructureSpacing
 - Spryker.ControlStructures.DisallowCloakingCheck
+- Spryker.ControlStructures.ElseIfDeclaration
 - Spryker.ControlStructures.NoInlineAssignment
 - Spryker.DependencyProvider.FacadeNotInBridgeReturned
 - Spryker.Factory.CreateVsGetMethods


### PR DESCRIPTION
Turns out
```xml
<rule ref="PSR2"/>
```
includes elseif but only as warning.

PSR2 (12 sniffs)
----------------
- PSR2.Classes.ClassDeclaration
- PSR2.Classes.PropertyDeclaration
- PSR2.ControlStructures.ControlStructureSpacing
- PSR2.ControlStructures.ElseIfDeclaration
- PSR2.ControlStructures.SwitchDeclaration
- PSR2.Files.ClosingTag
- PSR2.Files.EndFileNewline
- PSR2.Methods.FunctionCallSignature
- PSR2.Methods.FunctionClosingBrace
- PSR2.Methods.MethodDeclaration
- PSR2.Namespaces.NamespaceDeclaration
- PSR2.Namespaces.UseDeclaration

But we need it as error and fixable, so we add it as

    Spryker.ControlStructures.ElseIfDeclaration
