### PR TITLE
FRW-332 Fix up PHPStan and typeless param.

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -10,6 +10,7 @@ namespace Spryker\Sniffs\Commenting;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 use Spryker\Traits\CommentingTrait;
 
@@ -126,9 +127,9 @@ class DocBlockConstSniff extends AbstractSprykerSniff
             return;
         }
 
-        /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode $valueNode */
+        /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode $valueNode */
         $valueNode = static::getValueNode($tokens[$tagIndex]['content'], $content);
-        if ($valueNode instanceof InvalidTagValueNode) {
+        if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
             return;
         }
         $parts = $this->valueNodeParts($valueNode);

--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -9,6 +9,7 @@ namespace Spryker\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 use Spryker\Traits\CommentingTrait;
 use Spryker\Traits\SignatureTrait;
@@ -87,9 +88,9 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
                 continue;
             }
 
-            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode $valueNode */
+            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode $valueNode */
             $valueNode = static::getValueNode($tokens[$i]['content'], $content);
-            if ($valueNode instanceof InvalidTagValueNode) {
+            if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
                 return;
             }
             $parts = $this->valueNodeParts($valueNode);

--- a/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamArraySniff.php
@@ -9,6 +9,7 @@ namespace Spryker\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 use Spryker\Traits\CommentingTrait;
 
@@ -63,9 +64,9 @@ class DocBlockParamArraySniff extends AbstractSprykerSniff
             }
 
             $content = $tokens[$classNameIndex]['content'];
-            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
+            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
             $valueNode = static::getValueNode($tokens[$i]['content'], $content);
-            if ($valueNode instanceof InvalidTagValueNode) {
+            if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
                 return;
             }
             $parts = $this->valueNodeParts($valueNode);

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullSniff.php
@@ -11,6 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use Spryker\Traits\BasicsTrait;
 use Spryker\Traits\CommentingTrait;
 
@@ -87,9 +88,9 @@ class DocBlockReturnNullSniff implements Sniff
                 continue;
             }
 
-            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
+            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
             $valueNode = static::getValueNode($tokens[$i]['content'], $content);
-            if ($valueNode instanceof InvalidTagValueNode) {
+            if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
                 return;
             }
             $parts = $this->valueNodeParts($valueNode);

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
@@ -9,6 +9,7 @@ namespace Spryker\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use RuntimeException;
 use SlevomatCodingStandard\Helpers\DocCommentHelper;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
@@ -85,9 +86,9 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
         $tokens = $phpCsFile->getTokens();
 
         $content = $tokens[$stackPointer]['content'];
-        /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
+        /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
         $valueNode = static::getValueNode($tokens[$stackPointer - 2]['content'], $content);
-        if ($valueNode instanceof InvalidTagValueNode) {
+        if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
             return [];
         }
 

--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -9,6 +9,7 @@ namespace Spryker\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
 use Spryker\Traits\CommentingTrait;
 
@@ -61,9 +62,9 @@ class DocBlockReturnTagSniff extends AbstractSprykerSniff
         $tokens = $phpcsFile->getTokens();
 
         $content = $tokens[$nextIndex]['content'];
-        /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
+        /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
         $valueNode = static::getValueNode($tokens[$stackPtr]['content'], $content);
-        if ($valueNode instanceof InvalidTagValueNode) {
+        if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
             return;
         }
 

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -11,6 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use Spryker\Traits\CommentingTrait;
 
 /**
@@ -84,9 +85,9 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
                 continue;
             }
 
-            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode $valueNode */
+            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode $valueNode */
             $valueNode = static::getValueNode($tokens[$i]['content'], $content);
-            if ($valueNode instanceof InvalidTagValueNode) {
+            if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
                 return;
             }
 

--- a/Spryker/Sniffs/Commenting/TypeHintSniff.php
+++ b/Spryker/Sniffs/Commenting/TypeHintSniff.php
@@ -22,6 +22,7 @@ use PHP_CodeSniffer\Files\File;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
@@ -116,7 +117,7 @@ class TypeHintSniff extends AbstractSprykerSniff
 
             $tagComment = $phpcsFile->fixer->getTokenContent($tag + 2);
             $valueNode = static::getValueNode($tokens[$tag]['content'], $tagComment);
-            if ($valueNode instanceof InvalidTagValueNode) {
+            if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
                 continue;
             }
 


### PR DESCRIPTION
Refs https://github.com/spryker/architecture-sniffer/actions/runs/3128055518/jobs/5075409110
```
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: Undefined property: PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode::$type in
   |       | /work/docker/suite-nonsplit/vendor/spryker/architecture-sniffer/vendor/spryker/code-sniffer/Spryker/Sniffs/Commenting/TypeHintSniff.php on line 124 (Internal.Exception)
```

For now this can be merge only as we need it internally, we can release this with the next patch release scheduled.