### PR TITLE
Fix false positive

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -222,7 +222,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
      */
     protected function isPrimitiveGenerics(string $type, array $parts): bool
     {
-        $iterableTypes = ['array', 'iterable'];
+        $iterableTypes = ['array', 'iterable', 'list'];
         if (!in_array($type, $iterableTypes, true)) {
             return false;
         }


### PR DESCRIPTION
Resolves
```php
    /**
     * @param list<\Some\Plugin\List> $x
     *
     * @return void
     */
    public function foo(array $x)
    {
    }
```
not being allowed as valid syntax.