### PR TITLE
SDK-5711: Removed unused enableNeverTypeHint.

### DIFF
--- a/SprykerStrict/ruleset.xml
+++ b/SprykerStrict/ruleset.xml
@@ -17,7 +17,6 @@
             <property name="enableMixedTypeHint" value="false"/>
             <property name="enableUnionTypeHint" value="false"/>
             <property name="enableIntersectionTypeHint" value="false"/>
-            <property name="enableNeverTypeHint" value="false"/>
         </properties>
     </rule>
     <rule ref="SprykerStrict.TypeHints.ReturnTypeHint">


### PR DESCRIPTION
## PR Description

- Fixed issue `ERROR: Ruleset invalid. Property "enableNeverTypeHint" does not exist on sniff SprykerStrict.TypeHints.ParameterTypeHint`.

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
