### PR TITLE
FRW-7647 Removed deprecated `getQueryContainer()` annotation validation.

### DIFF
--- a/Spryker/Sniffs/MethodAnnotation/QueryContainerMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/QueryContainerMethodAnnotationSniff.php
@@ -41,30 +41,6 @@ class QueryContainerMethodAnnotationSniff extends AbstractMethodAnnotationSniff
      */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
-        if ($this->isController($phpCsFile, $stackPointer)) {
-            return true;
-        }
-
-        if ($this->isCollectionType($phpCsFile, $stackPointer)) {
-            return true;
-        }
-
-        if ($this->isConsole($phpCsFile, $stackPointer)) {
-            return true;
-        }
-
-        if ($this->isFactory($phpCsFile, $stackPointer)) {
-            return true;
-        }
-
-        if ($this->isPlugin($phpCsFile, $stackPointer)) {
-            return true;
-        }
-
-        if ($this->isType($phpCsFile, $stackPointer)) {
-            return true;
-        }
-
         return false;
     }
 


### PR DESCRIPTION
- Developer(s): @olhalivitchuk 

- Ticket: https://spryker.atlassian.net/browse/FRW-7647

- Release Group: https://release.spryker.com/release-groups/view/5352

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CodeSniffer         | patch                 |                       |

-----------------------------------------

#### Module DynamicEntity

##### Change log

Fixes

- Adjusted `QueryContainerMethodAnnotationSniff` to remove deprecated `getQueryContainer()` annotation validation.

