### PR TITLE
FRW-8590 Fixed false negative error for specification annotation.

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -23,7 +23,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     /**
      * @var string
      */
-    protected const SPECIFICATION_TAG = 'Specification:';
+    protected const SPECIFICATION_TAG = 'Specification';
 
     /**
      * @inheritDoc
@@ -324,11 +324,12 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
             return null;
         }
 
+        $apiTagPosition = $this->findApiAnnotationIndex($phpCsFile, $stackPointer);
         $specificationPosition = $this->getContentPositionInRange(
             static::SPECIFICATION_TAG,
             $tokens,
             $docCommentOpenerPosition,
-            $docCommentClosingPosition,
+            $apiTagPosition ?? $docCommentClosingPosition,
         );
         if (!$specificationPosition) {
             return null;
@@ -348,7 +349,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     {
         $tokens = $phpCsFile->getTokens();
         $tokenContent = $tokens[$stackPointer]['content'];
-        if ($tokenContent === sprintf('%s', static::SPECIFICATION_TAG)) {
+        if ($tokenContent === sprintf('%s:', static::SPECIFICATION_TAG)) {
             return;
         }
         $this->addTypoInSpecificationTagFixableError($phpCsFile, $stackPointer);

--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -23,7 +23,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     /**
      * @var string
      */
-    protected const SPECIFICATION_TAG = 'Specification';
+    protected const SPECIFICATION_TAG = 'Specification:';
 
     /**
      * @inheritDoc
@@ -348,7 +348,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     {
         $tokens = $phpCsFile->getTokens();
         $tokenContent = $tokens[$stackPointer]['content'];
-        if ($tokenContent === sprintf('%s:', static::SPECIFICATION_TAG)) {
+        if ($tokenContent === sprintf('%s', static::SPECIFICATION_TAG)) {
             return;
         }
         $this->addTypoInSpecificationTagFixableError($phpCsFile, $stackPointer);


### PR DESCRIPTION
- Developer(s): @geega 

- Ticket: https://spryker.atlassian.net/browse/FRW-8590

- Release Group: https://release.spryker.com/release-groups/view/5416

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CodeSniffer         | patch                 |                       |

-----------------------------------------

#### Module DynamicEntity

##### Change log

Fixes

- Adjusted `DocBlockApiAnnotationSniff` to fix the false negative errors when declaring the `Specification` annotation. 
