### PR TITLE
FRW-8801 Dropped PHP 8.0 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.0'
-          - '8.2'
+          - '8.1'
+          - '8.3'
 
     steps:
       - name: Setup PHP
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.0'
+          - '8.1'
 
     steps:
       - name: Setup PHP
@@ -96,7 +96,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 [![CI](https://github.com/spryker/code-sniffer/workflows/CI/badge.svg)](https://github.com/spryker/code-sniffer/actions?query=workflow%3ACI+branch%3Amaster)
 [![Latest Stable Version](https://poser.pugx.org/spryker/code-sniffer/v/stable.svg)](https://packagist.org/packages/spryker/code-sniffer)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat)](https://phpstan.org/)
 [![License](https://poser.pugx.org/spryker/code-sniffer/license.svg)](https://packagist.org/packages/spryker/code-sniffer)
 [![Total Downloads](https://poser.pugx.org/spryker/code-sniffer/d/total.svg)](https://packagist.org/packages/spryker/code-sniffer)

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -216,7 +216,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         }
 
         if (!preg_match('|^\$[a-z0-9]+$|i', $contentMatches[3])) {
-            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . $contentMatches[2] ?? '' . $contentMatches[3] ?? '' . '`';
+            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . (isset($contentMatches[2]) ? $contentMatches[2] : '') . (isset($contentMatches[3]) ? $contentMatches[3] : '') . '`';
         }
 
         return $errors;

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -216,7 +216,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         }
 
         if (!preg_match('|^\$[a-z0-9]+$|i', $contentMatches[3])) {
-            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . $contentMatches[2] . $contentMatches[3] . '`';
+            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . $contentMatches[2] ?? '' . $contentMatches[3] ?? '' . '`';
         }
 
         return $errors;

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -216,7 +216,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         }
 
         if (!preg_match('|^\$[a-z0-9]+$|i', $contentMatches[3])) {
-            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . (isset($contentMatches[2]) ? $contentMatches[2] : '') . $contentMatches[3] . '`';
+            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . ($contentMatches[2] ?? '') . $contentMatches[3] . '`';
         }
 
         return $errors;

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -216,7 +216,7 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         }
 
         if (!preg_match('|^\$[a-z0-9]+$|i', $contentMatches[3])) {
-            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . (isset($contentMatches[2]) ? $contentMatches[2] : '') . (isset($contentMatches[3]) ? $contentMatches[3] : '') . '`';
+            $errors['order'] = 'Expected ´{Type} ${var}´, got `' . $contentMatches[1] . (isset($contentMatches[2]) ? $contentMatches[2] : '') . $contentMatches[3] . '`';
         }
 
         return $errors;

--- a/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
@@ -28,7 +28,7 @@ class SprykerDisallowFunctionsSniff extends AbstractSprykerSniff
     /**
      * @var string
      */
-    protected const PHP_MIN = '8.0';
+    protected const PHP_MIN = '8.1';
 
     /**
      * This property can be filled with the current PHP version in use.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
         "squizlabs/php_codesniffer": "^3.6.2"
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ If you want to enable `Spryker.Internal.SprykerDisallowFunctions` for your proje
 ```xml
     <rule ref="Spryker.Internal.SprykerDisallowFunctions">
         <properties>
-            <property name="phpVersion" value="8.0"/>
+            <property name="phpVersion" value="8.1"/>
         </properties>
     </rule>
 ```


### PR DESCRIPTION
- Developer(s): @olhalivitchuk  

- Ticket: https://spryker.atlassian.net/browse/FRW-8801

- Release Group: https://release.spryker.com/release-groups/view/5551

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CodeSniffer             | patch (currently 0.x)          |                       |

-----------------------------------------

#### Module CodeSniffer

##### Change log

Improvements 

- Added `PHP 8.3` support.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
