### PR TITLE
AE-157 Null safe operator usage enabling

### DIFF
--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -234,6 +234,5 @@
     <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse"/>
     <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
 
 </ruleset>


### PR DESCRIPTION
## PR Description
Null safe object operator is a useful syntactical sugar, introduced in [PHP 8.0](https://php.watch/versions/8.0/null-safe-operator) .

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
