### PR TITLE
FRW-9988 Fixed constrains in composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "phpstan/phpdoc-parser": "^1.33.0",
         "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
         "squizlabs/php_codesniffer": "^3.6.2"
     },


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/FRW-9988

## Improvements
- Locked the usage version for `phpstan/phpdoc-parser` used in the tool.