### PR TITLE
FRW-10648 Added PHP 8.4 Support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.1'
-          - '8.3'
+          - '8.2'
+          - '8.4'
 
     steps:
       - name: Setup PHP
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.1'
+          - '8.2'
 
     steps:
       - name: Setup PHP
@@ -96,7 +96,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spryker Code Sniffer
 [![CI](https://github.com/spryker/code-sniffer/workflows/CI/badge.svg)](https://github.com/spryker/code-sniffer/actions?query=workflow%3ACI+branch%3Amaster)
 [![Latest Stable Version](https://poser.pugx.org/spryker/code-sniffer/v/stable.svg)](https://packagist.org/packages/spryker/code-sniffer)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg)](https://php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat)](https://phpstan.org/)
 [![License](https://poser.pugx.org/spryker/code-sniffer/license.svg)](https://packagist.org/packages/spryker/code-sniffer)
 [![Total Downloads](https://poser.pugx.org/spryker/code-sniffer/d/total.svg)](https://packagist.org/packages/spryker/code-sniffer)

--- a/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
@@ -28,7 +28,7 @@ class SprykerDisallowFunctionsSniff extends AbstractSprykerSniff
     /**
      * @var string
      */
-    protected const PHP_MIN = '8.1';
+    protected const PHP_MIN = '8.2';
 
     /**
      * This property can be filled with the current PHP version in use.

--- a/Spryker/ruleset.xml
+++ b/Spryker/ruleset.xml
@@ -235,9 +235,4 @@
         </properties>
     </rule>
 
-    <!-- Disallow PHP8 specific behavior until code is PHP8+ only, projects can remove/silence those -->
-    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration"/>
-    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse"/>
-    <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
-
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "phpstan/phpdoc-parser": "^1.33.0",
         "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
         "squizlabs/php_codesniffer": "^3.6.2"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.0.0",
+        "phpstan/phpstan": "^1.11.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ If you want to enable `Spryker.Internal.SprykerDisallowFunctions` for your proje
 ```xml
     <rule ref="Spryker.Internal.SprykerDisallowFunctions">
         <properties>
-            <property name="phpVersion" value="8.1"/>
+            <property name="phpVersion" value="8.2"/>
         </properties>
     </rule>
 ```


### PR DESCRIPTION
- Developer(s): @olhalivitchuk  

- Ticket: https://spryker.atlassian.net/browse/FRW-10648

- Release Group: https://release.spryker.com/release-groups/view/6080

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CodeSniffer             | patch (currently 0.x)          |                       |

-----------------------------------------

#### Module CodeSniffer

##### Change log

Improvements 

- Added `PHP 8.4` support.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
