### PR TITLE
Fixed doc block default value matching

### DIFF
--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -54,9 +54,9 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             return;
         }
 
-        $parameterMap = [];
+        $parametersIndexedByName = [];
         foreach ($methodSignature as $parameter) {
-            $parameterMap[$parameter['variable']] = $parameter;
+            $parametersIndexedByName[$parameter['variable']] = $parameter;
         }
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
@@ -89,11 +89,11 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
             }
             $parts = $this->valueNodeParts($valueNode);
 
-            if (!isset($parameterMap[$valueNode->parameterName])) {
+            if (!isset($parametersIndexedByName[$valueNode->parameterName])) {
                 continue;
             }
 
-            $methodSignatureValue = $parameterMap[$valueNode->parameterName];
+            $methodSignatureValue = $parametersIndexedByName[$valueNode->parameterName];
 
             if (empty($methodSignatureValue['typehint']) && empty($methodSignatureValue['default'])) {
                 continue;


### PR DESCRIPTION
## PR Description
Fixed doc block default value matching.

Previously, the sniff used a sequential counter to match `@param` tags
with method signature parameters by their position. This caused
incorrect type suggestions when only some parameters were documented
in the doc block.

Example that now works correctly:
```php
  /**
   * @param array<string, mixed> $c
   */
  protected function doSomething(int $a, int $b, array $c): void
```

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/code-sniffer/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
