### PR TITLE
Update slevomat/coding-standard version to ^8.14.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=8.2",
         "phpstan/phpdoc-parser": "^1.33.0",
-        "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
+        "slevomat/coding-standard": "^8.13.0",
         "squizlabs/php_codesniffer": "^3.6.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=8.2",
         "phpstan/phpdoc-parser": "^1.33.0",
-        "slevomat/coding-standard": "^8.13.0",
+        "slevomat/coding-standard": "^8.14.0",
         "squizlabs/php_codesniffer": "^3.6.2"
     },
     "require-dev": {


### PR DESCRIPTION
## PR Description
`vendor/bin/console code:sniff:style` is failing because of unknown method usage:

`Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php` uses `Annotation->getValue()` methods that was introduced only in [8.13](https://github.com/slevomat/coding-standard/compare/8.12.0...8.13.0)

and in [8.14](https://github.com/slevomat/coding-standard/releases/tag/8.14.0) was fixed the bug with `SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation`

proofs:
<img width="1251" height="858" alt="image" src="https://github.com/user-attachments/assets/b167e06a-ebe1-4289-b5b4-f8b347459e8e" />

<img width="1262" height="221" alt="image" src="https://github.com/user-attachments/assets/664b71ed-aac5-4c5e-b187-d402712ac075" />



## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/code-sniffer/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
