### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please see the Spryker Coding conventions for details.
 ## Documentation
 See **[docs](docs/README.md)**.
 
-Upstream docs: [squizlabs/PHP_CodeSniffer/wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki)
+Upstream docs: [squizlabs/PHP_CodeSniffer/wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki)
 
 ## Usage
 
@@ -69,7 +69,7 @@ You can also set up file watchers, but here you should better only whitelist cer
 
 ### How to configure the default rule set
 
-In order to simplify command line interface, `phpcs` allows to specify [default rule set](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-default-coding-standard) in and [standards path](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths) the following way.
+In order to simplify command line interface, `phpcs` allows to specify [default rule set](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-default-coding-standard) in and [standards path](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths) the following way.
 
 Assuming the following directory structure:
 

--- a/Spryker/Sniffs/Classes/ClassFileNameSniff.php
+++ b/Spryker/Sniffs/Classes/ClassFileNameSniff.php
@@ -21,7 +21,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  * @author Greg Sherwood <gsherwood@squiz.net>
  * @author Marc McIntyre <mmcintyre@squiz.net>
  * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version Release: @package_version@
  * @link http://pear.php.net/package/PHP_CodeSniffer
  */

--- a/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
+++ b/Spryker/Sniffs/Classes/MethodDeclarationSniff.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @author Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version Release: @package_version@
  * @link http://pear.php.net/package/PHP_CodeSniffer
  */

--- a/Spryker/Sniffs/Commenting/DocCommentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocCommentSniff.php
@@ -15,7 +15,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  *
  * @author Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version Release: @package_version@
  * @link http://pear.php.net/package/PHP_CodeSniffer
  */

--- a/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
+++ b/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @author Greg Sherwood <gsherwood@squiz.net>
  * @author Marc McIntyre <mmcintyre@squiz.net>
  * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @link http://pear.php.net/package/PHP_CodeSniffer
  *
  * @modified by Mark Scherer with some minor fixes and removal of error-prone parts


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932