### PR TITLE
Honor inline {@inheritDoc} in hasInheritDoc

### DIFF
--- a/Spryker/Traits/CommentingTrait.php
+++ b/Spryker/Traits/CommentingTrait.php
@@ -144,14 +144,8 @@ trait CommentingTrait
             if (empty($tokens[$i]['content'])) {
                 continue;
             }
-            $content = $tokens[$i]['content'];
-            $pos = stripos($content, $needle);
-            if ($pos === false) {
+            if (stripos($tokens[$i]['content'], $needle) === false) {
                 continue;
-            }
-
-            if ($pos && strpos($needle, '@') === 0 && substr($content, $pos - 1, $pos) === '{') {
-                return false;
             }
 
             return true;

--- a/tests/Spryker/Sniffs/Commenting/DocBlockParamSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockParamSniffTest.php
@@ -15,7 +15,8 @@ class DocBlockParamSniffTest extends TestCase
     /**
      * Two `ExtraParam` (stale + no-arg stray) and three `RequiredParamMissing` (array, untyped, and
      * an `array|string` union whose array member still hides the element type/shape). The
-     * documented-subset, documented-union and fully-omitted-redundant cases must produce no error.
+     * documented-subset, documented-union, fully-omitted-redundant and inline-`{@inheritDoc}` cases
+     * must produce no error.
      *
      * @return void
      */

--- a/tests/_data/DocBlockParam/before.php
+++ b/tests/_data/DocBlockParam/before.php
@@ -107,4 +107,14 @@ class DocBlockParam
     public function unionArrayDocumented(array|string $rows): void
     {
     }
+
+    /**
+     * Inline `{@inheritDoc}` defers entirely to the parent, so the array param needs no `@param`
+     * (the same as the bare `@inheritDoc` tag).
+     *
+     * {@inheritDoc}
+     */
+    public function inlineInheritDocUndocumented(string $target, array $rows): void
+    {
+    }
 }


### PR DESCRIPTION
`CommentingTrait::hasInheritDoc()` documents that it matches **both** `@inheritDoc` and the inline `{@inheritDoc}` form, but a buggy guard returned `false` for the brace form:

```php
if ($pos && strpos($needle, '@') === 0 && substr($content, $pos - 1, $pos) === '{') {
    return false;
}
```

The third argument of `substr()` is a length, not an end offset, so this never reliably detected the leading `{` it was meant to. As a result methods documented with inline `{@inheritDoc}` were not recognised as inheriting, and `DocBlockParamSniff`, `DocBlockReturnVoidSniff`, `DocBlockConstSniff` and `DocBlockApiAnnotationSniff` still demanded full doc blocks on them.

Fix: match both forms as the method already documents. Added a `DocBlockParam` regression fixture (`inlineInheritDocUndocumented`) that must produce no error.

Full suite green (42 tests).
