### PR TITLE
CC-39568 Allow phpstan/phpdoc-parser v2 alongside v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
         php-version:
           - '8.2'
           - '8.4'
+        phpdoc-parser:
+          - '^1.33.0'
+          - '^2.1.0'
 
     steps:
       - name: Setup PHP
@@ -43,6 +46,9 @@ jobs:
 
       - name: Composer install
         run: composer install --optimize-autoloader
+
+      - name: Select phpstan/phpdoc-parser ${{ matrix.phpdoc-parser }}
+        run: composer update "phpstan/phpdoc-parser:${{ matrix.phpdoc-parser }}" slevomat/coding-standard -W
 
       - name: Run tests
         run: composer test

--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -16,10 +16,12 @@ use SlevomatCodingStandard\Helpers\EmptyFileException;
 use SlevomatCodingStandard\Helpers\NamespaceHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use Spryker\Traits\BasicsTrait;
+use Spryker\Traits\TokenHelperCompatTrait;
 
 abstract class AbstractSprykerSniff implements Sniff
 {
     use BasicsTrait;
+    use TokenHelperCompatTrait;
 
     /**
      * @var string
@@ -183,36 +185,6 @@ abstract class AbstractSprykerSniff implements Sniff
             $phpCsFile,
             $prevIndex,
         );
-    }
-
-    /**
-     * Resolves a Slevomat `TokenHelper` token-code list by name, tolerating its move from a
-     * public static property (Slevomat < 8.16) to a class constant (Slevomat >= 8.16). The
-     * name is resolved dynamically so neither form appears as a static literal that would be
-     * rejected by static analysis against whichever Slevomat version is installed.
-     *
-     * @param string $constantName
-     * @param string $propertyName
-     *
-     * @return array<int|string>
-     */
-    protected function resolveTokenHelperCodes(string $constantName, string $propertyName): array
-    {
-        $qualifiedConstantName = TokenHelper::class . '::' . $constantName;
-        $codes = defined($qualifiedConstantName)
-            ? constant($qualifiedConstantName)
-            : TokenHelper::${$propertyName};
-
-        $result = [];
-        if (is_array($codes)) {
-            foreach ($codes as $code) {
-                if (is_int($code) || is_string($code)) {
-                    $result[] = $code;
-                }
-            }
-        }
-
-        return $result;
     }
 
     /**

--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -171,7 +171,10 @@ abstract class AbstractSprykerSniff implements Sniff
             return null;
         }
 
-        $prevIndex = $phpCsFile->findPrevious(TokenHelper::$typeKeywordTokenCodes, $lastToken);
+        $prevIndex = $phpCsFile->findPrevious(
+            $this->resolveTokenHelperCodes('CLASS_TYPE_TOKEN_CODES', 'typeKeywordTokenCodes'),
+            $lastToken,
+        );
         if (!$prevIndex) {
             return null;
         }
@@ -180,6 +183,36 @@ abstract class AbstractSprykerSniff implements Sniff
             $phpCsFile,
             $prevIndex,
         );
+    }
+
+    /**
+     * Resolves a Slevomat `TokenHelper` token-code list by name, tolerating its move from a
+     * public static property (Slevomat < 8.16) to a class constant (Slevomat >= 8.16). The
+     * name is resolved dynamically so neither form appears as a static literal that would be
+     * rejected by static analysis against whichever Slevomat version is installed.
+     *
+     * @param string $constantName
+     * @param string $propertyName
+     *
+     * @return array<int|string>
+     */
+    protected function resolveTokenHelperCodes(string $constantName, string $propertyName): array
+    {
+        $qualifiedConstantName = TokenHelper::class . '::' . $constantName;
+        $codes = defined($qualifiedConstantName)
+            ? constant($qualifiedConstantName)
+            : TokenHelper::${$propertyName};
+
+        $result = [];
+        if (is_array($codes)) {
+            foreach ($codes as $code) {
+                if (is_int($code) || is_string($code)) {
+                    $result[] = $code;
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -30,6 +30,7 @@ use SlevomatCodingStandard\Helpers\NamespaceHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Helpers\TypeHintHelper;
+use Spryker\Traits\TokenHelperCompatTrait;
 
 /**
  * Fixed version of Slevomatic, touching collection objects the right way.
@@ -38,6 +39,8 @@ use SlevomatCodingStandard\Helpers\TypeHintHelper;
  */
 class DisallowArrayTypeHintSyntaxSniff implements Sniff
 {
+    use TokenHelperCompatTrait;
+
     /**
      * @var string
      */
@@ -354,36 +357,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         }
 
         return null;
-    }
-
-    /**
-     * Resolves a Slevomat `TokenHelper` token-code list by name, tolerating its move from a
-     * public static property (Slevomat < 8.16) to a class constant (Slevomat >= 8.16). The
-     * name is resolved dynamically so neither form appears as a static literal that would be
-     * rejected by static analysis against whichever Slevomat version is installed.
-     *
-     * @param string $constantName
-     * @param string $propertyName
-     *
-     * @return array<int|string>
-     */
-    protected function resolveTokenHelperCodes(string $constantName, string $propertyName): array
-    {
-        $qualifiedConstantName = TokenHelper::class . '::' . $constantName;
-        $codes = defined($qualifiedConstantName)
-            ? constant($qualifiedConstantName)
-            : TokenHelper::${$propertyName};
-
-        $result = [];
-        if (is_array($codes)) {
-            foreach ($codes as $code) {
-                if (is_int($code) || is_string($code)) {
-                    $result[] = $code;
-                }
-            }
-        }
-
-        return $result;
     }
 
     /**

--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -303,7 +303,11 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                 return null;
             }
 
-            $functionPointer = TokenHelper::findNext($phpcsFile, TokenHelper::$functionTokenCodes, $docCommentOpenPointer + 1);
+            $functionPointer = TokenHelper::findNext(
+                $phpcsFile,
+                $this->resolveTokenHelperCodes('FUNCTION_TOKEN_CODES', 'functionTokenCodes'),
+                $docCommentOpenPointer + 1,
+            );
 
             if ($functionPointer === null || $phpcsFile->getTokens()[$functionPointer]['code'] !== T_FUNCTION) {
                 return null;
@@ -350,6 +354,36 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         }
 
         return null;
+    }
+
+    /**
+     * Resolves a Slevomat `TokenHelper` token-code list by name, tolerating its move from a
+     * public static property (Slevomat < 8.16) to a class constant (Slevomat >= 8.16). The
+     * name is resolved dynamically so neither form appears as a static literal that would be
+     * rejected by static analysis against whichever Slevomat version is installed.
+     *
+     * @param string $constantName
+     * @param string $propertyName
+     *
+     * @return array<int|string>
+     */
+    protected function resolveTokenHelperCodes(string $constantName, string $propertyName): array
+    {
+        $qualifiedConstantName = TokenHelper::class . '::' . $constantName;
+        $codes = defined($qualifiedConstantName)
+            ? constant($qualifiedConstantName)
+            : TokenHelper::${$propertyName};
+
+        $result = [];
+        if (is_array($codes)) {
+            foreach ($codes as $code) {
+                if (is_int($code) || is_string($code)) {
+                    $result[] = $code;
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/Spryker/Traits/CommentingTrait.php
+++ b/Spryker/Traits/CommentingTrait.php
@@ -21,6 +21,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use ReflectionClass;
 
 /**
  * Common functionality around commenting.
@@ -36,17 +37,40 @@ trait CommentingTrait
     protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode
     {
         static $phpDocParser;
-        if (!$phpDocParser) {
-            $constExprParser = new ConstExprParser();
-            $phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
-        }
-
         static $phpDocLexer;
-        if (!$phpDocLexer) {
-            $phpDocLexer = new Lexer();
+        if (!$phpDocParser || !$phpDocLexer) {
+            [$phpDocParser, $phpDocLexer] = static::createPhpDocParser();
         }
 
         return $phpDocParser->parseTagValue(new TokenIterator($phpDocLexer->tokenize($tagComment)), $tagName);
+    }
+
+    /**
+     * Builds a parser/lexer pair that works with both phpstan/phpdoc-parser v1 and v2.
+     *
+     * v2 requires a `ParserConfig` as the first constructor argument on the lexer and every
+     * parser; v1 has no such argument. The instances are created through reflection so that
+     * neither the v1 nor the v2 call shape appears as a static literal that static analysis
+     * would reject against whichever single version happens to be installed.
+     *
+     * @return array{\PHPStan\PhpDocParser\Parser\PhpDocParser, \PHPStan\PhpDocParser\Lexer\Lexer}
+     */
+    protected static function createPhpDocParser(): array
+    {
+        $parserConfigClass = 'PHPStan\PhpDocParser\ParserConfig';
+
+        $configArguments = [];
+        if (class_exists($parserConfigClass)) {
+            $configArguments[] = (new ReflectionClass($parserConfigClass))
+                ->newInstanceArgs([['lines' => true, 'indexes' => true]]);
+        }
+
+        $constExprParser = (new ReflectionClass(ConstExprParser::class))->newInstanceArgs($configArguments);
+        $typeParser = (new ReflectionClass(TypeParser::class))->newInstanceArgs(array_merge($configArguments, [$constExprParser]));
+        $phpDocParser = (new ReflectionClass(PhpDocParser::class))->newInstanceArgs(array_merge($configArguments, [$typeParser, $constExprParser]));
+        $phpDocLexer = (new ReflectionClass(Lexer::class))->newInstanceArgs($configArguments);
+
+        return [$phpDocParser, $phpDocLexer];
     }
 
     /**

--- a/Spryker/Traits/TokenHelperCompatTrait.php
+++ b/Spryker/Traits/TokenHelperCompatTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Traits;
+
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+trait TokenHelperCompatTrait
+{
+    /**
+     * Resolves a Slevomat `TokenHelper` token-code list by name, tolerating its move from a
+     * public static property (Slevomat < 8.16) to a class constant (Slevomat >= 8.16). The
+     * name is resolved dynamically so neither form appears as a static literal that would be
+     * rejected by static analysis against whichever Slevomat version is installed.
+     *
+     * @return array<int|string>
+     */
+    protected function resolveTokenHelperCodes(string $constantName, string $propertyName): array
+    {
+        $qualifiedConstantName = TokenHelper::class . '::' . $constantName;
+        $codes = defined($qualifiedConstantName)
+            ? constant($qualifiedConstantName)
+            : TokenHelper::${$propertyName};
+
+        $result = [];
+        if (is_array($codes)) {
+            foreach ($codes as $code) {
+                if (is_int($code) || is_string($code)) {
+                    $result[] = $code;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phpstan/phpdoc-parser": "^1.33.0",
+        "phpstan/phpdoc-parser": "^1.33.0 || ^2.1.0",
         "slevomat/coding-standard": "^8.14.0",
         "squizlabs/php_codesniffer": "^3.6.2"
     },


### PR DESCRIPTION
Widens `phpstan/phpdoc-parser` to `^1.33.0 || ^2.1.0` and makes the three parser-consuming sniffs work against both parser v2 and the Slevomat `>= 8.16` `TokenHelper` API, so a consumer can adopt Slevomat's `ClassConstantTypeHint` (which needs parser v2) without losing the v1 path. `squizlabs/php_codesniffer: ^3.6.2` and `slevomat/coding-standard: ^8.14.0` are left unchanged — the `^3` cap naturally keeps Slevomat below 8.26 (which would require php_codesniffer v4).

What it does:
- `CommentingTrait` builds the lexer/parser through reflection (parser v2 requires a `ParserConfig` first constructor argument; v1 does not), so neither call shape is a static literal that fails analysis against the installed version.
- `AbstractSprykerSniff` and `DisallowArrayTypeHintSyntaxSniff` resolve the `TokenHelper` token-code lists that moved from a public static property (Slevomat < 8.16) to a class constant (Slevomat >= 8.16) via dynamic `defined()`/`constant()` lookup.
- CI `validation` matrix gains a parser-v2 leg (`composer update` to `^2.1.0`) alongside the existing v1 leg.

Closes #370

Test plan — all four gates (`composer test`, `stan`, `cs-check`, `xml`) run green on both dependency legs:
- v1: `phpstan/phpdoc-parser 1.33.0` + `slevomat/coding-standard 8.15.0` + `php_codesniffer 3.13.5`
- v2: `phpstan/phpdoc-parser 2.3.3` + `slevomat/coding-standard 8.22.1` + `php_codesniffer 3.13.5`

Follow-up (out of scope): Slevomat >= 8.16 deprecates `SlevomatCodingStandard.TypeHints.UnionTypeHintFormat` (referenced in `Spryker/ruleset.xml`) in favour of `DNFTypeHintFormat`. It only warns until Slevomat 9.0, so migrating that ruleset entry is left as a separate change.
