### PR TITLE
CC-39568 Remove redundant docblocks from code-sniffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.2'
+          - '8.3'
           - '8.4'
 
     steps:
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.2'
+          - '8.3'
 
     steps:
       - name: Setup PHP

--- a/GlueStreamSpecific/Sniffs/Classes/AbstractStringInConstantOnlySniff.php
+++ b/GlueStreamSpecific/Sniffs/Classes/AbstractStringInConstantOnlySniff.php
@@ -49,10 +49,5 @@ abstract class AbstractStringInConstantOnlySniff extends AbstractSprykerSniff
         $phpcsFile->addError($error, $stackPtr, 'NoMatch', $data);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     abstract protected function isRuleApplicable(File $phpCsFile): bool;
 }

--- a/GlueStreamSpecific/Sniffs/Classes/DependencyProviderStringInConstantOnlySniff.php
+++ b/GlueStreamSpecific/Sniffs/Classes/DependencyProviderStringInConstantOnlySniff.php
@@ -11,11 +11,6 @@ use PHP_CodeSniffer\Files\File;
 
 class DependencyProviderStringInConstantOnlySniff extends AbstractStringInConstantOnlySniff
 {
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isRuleApplicable(File $phpCsFile): bool
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/AbstractSniffs/AbstractApiClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractApiClassDetectionSprykerSniff.php
@@ -11,42 +11,18 @@ use PHP_CodeSniffer\Files\File;
 
 abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const API_FACADE = 'FACADE';
+    protected const string API_FACADE = 'FACADE';
 
-    /**
-     * @var string
-     */
-    protected const API_SERVICE = 'SERVICE';
+    protected const string API_SERVICE = 'SERVICE';
 
-    /**
-     * @var string
-     */
-    protected const API_CLIENT = 'CLIENT';
+    protected const string API_CLIENT = 'CLIENT';
 
-    /**
-     * @var string
-     */
-    protected const API_QUERY_CONTAINER = 'QUERY_CONTAINER';
+    protected const string API_QUERY_CONTAINER = 'QUERY_CONTAINER';
 
-    /**
-     * @var string
-     */
-    protected const API_PLUGIN = 'PLUGIN';
+    protected const string API_PLUGIN = 'PLUGIN';
 
-    /**
-     * @var string
-     */
-    protected const API_CONFIG = 'CONFIG';
+    protected const string API_CONFIG = 'CONFIG';
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string|null
-     */
     protected function sprykerApiClass(File $phpCsFile, int $stackPointer): ?string
     {
         if (!$this->hasNamespace($phpCsFile, $stackPointer) || !$this->hasClassOrInterfaceName($phpCsFile, $stackPointer)) {
@@ -78,12 +54,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isPublicMethod(File $phpCsFile, int $stackPointer): bool
     {
         $publicPosition = $phpCsFile->findFirstOnLine(T_PUBLIC, $stackPointer);
@@ -94,12 +64,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function hasNamespace(File $phpCsFile, int $stackPointer): bool
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $stackPointer);
@@ -110,12 +74,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function hasClassOrInterfaceName(File $phpCsFile, int $stackPointer): bool
     {
         $classOrInterfaceNamePosition = $phpCsFile->findPrevious([T_CLASS, T_INTERFACE], $stackPointer);
@@ -126,12 +84,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function extractNamespace(File $phpCsFile, int $stackPointer): string
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $stackPointer);
@@ -151,12 +103,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return $namespace;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getClassOrInterfaceName(File $phpCsFile, int $stackPointer): string
     {
         $classOrInterfacePosition = $phpCsFile->findPrevious([T_CLASS, T_INTERFACE], $stackPointer);
@@ -168,12 +114,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return $phpCsFile->getTokens()[$classOrInterfaceNamePosition]['content'];
     }
 
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return bool
-     */
     protected function isFacade(string $namespace, string $name): bool
     {
         if (preg_match('/^Spryker[a-zA-Z]*\\\\Zed\\\\[a-zA-Z]+\\\\Business$/', $namespace) && preg_match('/^(.*?)(Facade|FacadeInterface)$/', $name)) {
@@ -183,12 +123,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return false;
     }
 
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return bool
-     */
     protected function isService(string $namespace, string $name): bool
     {
         if ($name === 'AbstractService') {
@@ -201,12 +135,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return false;
     }
 
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return bool
-     */
     protected function isClient(string $namespace, string $name): bool
     {
         if (preg_match('/^Spryker[a-zA-Z]*\\\\Client\\\\[a-zA-Z]+$/', $namespace) && preg_match('/^(.+?)(Client|ClientInterface)$/', $name)) {
@@ -216,12 +144,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return false;
     }
 
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return bool
-     */
     protected function isPlugin(string $namespace, string $name): bool
     {
         if (preg_match('/^Spryker[a-zA-Z]*\\\\[a-zA-Z]+\\\\[a-zA-Z]+\\\\Dependency\\\\Plugin\b/', $namespace) && preg_match('/^\w+Interface$/', $name)) {
@@ -235,12 +157,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return false;
     }
 
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return bool
-     */
     protected function isQueryContainer(string $namespace, string $name): bool
     {
         if (preg_match('/^Spryker[a-zA-Z]*\\\\Zed\\\(.*?)\\\\Persistence$/', $namespace) && preg_match('/^(.*?)(QueryContainer|QueryContainerInterface)$/', $name)) {
@@ -250,12 +166,6 @@ abstract class AbstractApiClassDetectionSprykerSniff extends AbstractSprykerSnif
         return false;
     }
 
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return bool
-     */
     protected function isConfig(string $namespace, string $name): bool
     {
         if (preg_match('/^Spryker[a-zA-Z]*\\\\[a-zA-Z]+\\\\[a-zA-Z]+$/', $namespace) && preg_match('/^\w+Config$/', $name)) {

--- a/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
@@ -14,13 +14,6 @@ use Throwable;
 
 abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
 {
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $abstractName
-     *
-     * @return bool
-     */
     protected function extendsAbstract(File $phpCsFile, int $stackPointer, string $abstractName): bool
     {
         $extendedClassName = $phpCsFile->findExtendedClassName($stackPointer);
@@ -44,9 +37,6 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $file
-     * @param int $stackPointer
-     *
      * @return array<string>
      */
     protected function getParentClassesFor(File $file, int $stackPointer): array
@@ -82,12 +72,6 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
         return array_filter($parents);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $predefinedName
-     *
-     * @return bool
-     */
     protected function hasCorrectName(File $phpCsFile, string $predefinedName): bool
     {
         $className = $this->getClassName($phpCsFile);
@@ -100,67 +84,32 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
         return $relevantClassNamePart === $correctName;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isProvider(File $phpCsFile): bool
     {
         return $this->hasCorrectName($phpCsFile, 'DependencyProvider') && $this->isCore($phpCsFile);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isController(File $phpCsFile, int $stackPointer): bool
     {
         return $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractController');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isCollectionType(File $phpCsFile, int $stackPointer): bool
     {
         return $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractCollectionType');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isConsole(File $phpCsFile, int $stackPointer): bool
     {
         return $this->extendsAbstract($phpCsFile, $stackPointer, 'Console');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isFacade(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'Facade') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractFacade');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractFacade');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isFactory(File $phpCsFile, int $stackPointer): bool
     {
         if ($this->isBusinessFactory($phpCsFile, $stackPointer)) {
@@ -178,48 +127,24 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isBusinessFactory(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'BusinessFactory') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractBusinessFactory');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractBusinessFactory');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isCommunicationFactory(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'CommunicationFactory') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractCommunicationFactory');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractCommunicationFactory');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isPersistenceFactory(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'PersistenceFactory') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractPersistenceFactory');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractPersistenceFactory');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isPlugin(File $phpCsFile, int $stackPointer): bool
     {
         if (!$this->isFileInPluginDirectory($phpCsFile)) {
@@ -233,60 +158,31 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isFileInPluginDirectory(File $phpCsFile): bool
     {
         return (bool)preg_match('/Communication\/Plugin/', $phpCsFile->getFilename());
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isType(File $phpCsFile, int $stackPointer): bool
     {
         return $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractType');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isQueryContainer(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'QueryContainer') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractQueryContainer');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractQueryContainer');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isRepository(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'Repository') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractRepository');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractRepository');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isEntityManager(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'EntityManager') &&
-            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractEntityManager');
+        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractEntityManager');
     }
 }

--- a/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractClassDetectionSprykerSniff.php
@@ -107,7 +107,7 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
     protected function isFacade(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'Facade') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractFacade');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractFacade');
     }
 
     protected function isFactory(File $phpCsFile, int $stackPointer): bool
@@ -130,19 +130,19 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
     protected function isBusinessFactory(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'BusinessFactory') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractBusinessFactory');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractBusinessFactory');
     }
 
     protected function isCommunicationFactory(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'CommunicationFactory') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractCommunicationFactory');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractCommunicationFactory');
     }
 
     protected function isPersistenceFactory(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'PersistenceFactory') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractPersistenceFactory');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractPersistenceFactory');
     }
 
     protected function isPlugin(File $phpCsFile, int $stackPointer): bool
@@ -171,18 +171,18 @@ abstract class AbstractClassDetectionSprykerSniff extends AbstractSprykerSniff
     protected function isQueryContainer(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'QueryContainer') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractQueryContainer');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractQueryContainer');
     }
 
     protected function isRepository(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'Repository') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractRepository');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractRepository');
     }
 
     protected function isEntityManager(File $phpCsFile, int $stackPointer): bool
     {
         return $this->hasCorrectName($phpCsFile, 'EntityManager') &&
-        $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractEntityManager');
+            $this->extendsAbstract($phpCsFile, $stackPointer, 'AbstractEntityManager');
     }
 }

--- a/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractMethodAnnotationSniff.php
@@ -12,20 +12,11 @@ use SlevomatCodingStandard\Helpers\DocCommentHelper;
 
 abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const LAYER_PERSISTENCE = 'Persistence';
+    protected const string LAYER_PERSISTENCE = 'Persistence';
 
-    /**
-     * @var string
-     */
-    protected const LAYER_COMMUNICATION = 'Communication';
+    protected const string LAYER_COMMUNICATION = 'Communication';
 
-    /**
-     * @var string
-     */
-    protected const LAYER_BUSINESS = 'Business';
+    protected const string LAYER_BUSINESS = 'Business';
 
     /**
      * @var string
@@ -47,16 +38,8 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         ];
     }
 
-    /**
-     * @return string
-     */
     abstract protected function getMethodName(): string;
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     abstract protected function getMethodFileAddedName(File $phpCsFile): string;
 
     /**
@@ -71,12 +54,6 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         $this->runSniffer($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function runSniffer(File $phpCsFile, int $stackPointer): void
     {
         $foundInNamespace = $this->getNamespaceForFilename($phpCsFile);
@@ -109,11 +86,6 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string|null
-     */
     protected function getNamespaceForFilename(File $phpCsFile): ?string
     {
         $namespaces = explode(',', $this->namespaces);
@@ -136,13 +108,6 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
      * Checks if the '@method' annotation for the specific method already exists
      * in the class. When $strictCheck is set to true, the method also checks
      * whether the referenced namespace and the class name are as expected.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $namespace
-     * @param bool $strictCheck
-     *
-     * @return bool
      */
     protected function hasMethodAnnotation(File $phpCsFile, int $stackPointer, string $namespace, bool $strictCheck = false): bool
     {
@@ -177,25 +142,11 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $namespace
-     *
-     * @return bool
-     */
     protected function hasCorrectMethodAnnotation(File $phpCsFile, int $stackPointer, string $namespace): bool
     {
         return $this->hasMethodAnnotation($phpCsFile, $stackPointer, $namespace, true);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $namespacePart
-     *
-     * @return void
-     */
     protected function addMethodAnnotation(File $phpCsFile, int $stackPointer, string $namespacePart): void
     {
         $phpCsFile->fixer->beginChangeset();
@@ -226,13 +177,6 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $namespacePart
-     *
-     * @return void
-     */
     protected function changeMethodAnnotation(File $phpCsFile, int $stackPointer, string $namespacePart): void
     {
         $phpCsFile->fixer->beginChangeset();
@@ -255,40 +199,15 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     abstract protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool;
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     abstract protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string;
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function hasDocBlock(File $phpCsFile, int $stackPointer): bool
     {
         return DocCommentHelper::hasDocComment($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $className
-     * @param string $namespacePart
-     *
-     * @return bool
-     */
     protected function fileExists(File $phpCsFile, string $className, string $namespacePart): bool
     {
         $fileName = $phpCsFile->getFilename();
@@ -315,22 +234,11 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         return file_exists($fileName) || file_exists($vendorFileName);
     }
 
-    /**
-     * @param string $input
-     *
-     * @return string
-     */
     protected function toDashedCase(string $input): string
     {
         return strtolower((string)preg_replace('/[A-Z]/', '-\\0', lcfirst($input)));
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return int
-     */
     protected function getStackPointerOfClassBegin(File $phpCsFile, int $stackPointer): int
     {
         $abstractPosition = (int)$phpCsFile->findPrevious(T_ABSTRACT, $stackPointer);
@@ -345,13 +253,6 @@ abstract class AbstractMethodAnnotationSniff extends AbstractClassDetectionSpryk
         return $stackPointer;
     }
 
-    /**
-     * @param string $basePath
-     * @param string $namespace
-     * @param string $module
-     *
-     * @return string
-     */
     protected function getVendorPath(string $basePath, string $namespace, string $module): string
     {
         $namespaceElement = $this->toDashedCase($namespace);

--- a/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
+++ b/Spryker/Sniffs/AbstractSniffs/AbstractSprykerSniff.php
@@ -21,10 +21,7 @@ abstract class AbstractSprykerSniff implements Sniff
 {
     use BasicsTrait;
 
-    /**
-     * @var string
-     */
-    protected const NAMESPACE_SPRYKER = 'Spryker';
+    protected const string NAMESPACE_SPRYKER = 'Spryker';
 
     /**
      * @var array<string> These markers must remain as inline comments
@@ -33,12 +30,6 @@ abstract class AbstractSprykerSniff implements Sniff
         '@noinspection',
     ];
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function isPhpStormMarker(File $phpCsFile, int $stackPtr): bool
     {
         $tokens = $phpCsFile->getTokens();
@@ -59,11 +50,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isSprykerNamespace(File $phpCsFile): bool
     {
         $namespace = $this->getNamespace($phpCsFile);
@@ -73,11 +59,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * Get level of indentation, 0 based.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return int
      */
     protected function getIndentationLevel(File $phpcsFile, int $index): int
     {
@@ -95,11 +76,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return (int)($level / 4);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getNamespace(File $phpCsFile): string
     {
         $className = $this->getClassName($phpCsFile);
@@ -108,11 +84,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return $classNameParts[0];
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isCore(File $phpCsFile): bool
     {
         $namespace = $this->getNamespace($phpCsFile);
@@ -120,11 +91,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return strpos($namespace, static::NAMESPACE_SPRYKER) === 0;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getModule(File $phpCsFile): string
     {
         $className = $this->getClassName($phpCsFile);
@@ -137,11 +103,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return $classNameParts[2];
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getLayer(File $phpCsFile): string
     {
         $className = $this->getClassName($phpCsFile);
@@ -154,11 +115,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return $classNameParts[3];
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string|null
-     */
     protected function getClassNameWithNamespace(File $phpCsFile): ?string
     {
         try {
@@ -182,11 +138,6 @@ abstract class AbstractSprykerSniff implements Sniff
         );
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getClassName(File $phpCsFile): string
     {
         $namespace = $this->getClassNameWithNamespace($phpCsFile);
@@ -211,13 +162,7 @@ abstract class AbstractSprykerSniff implements Sniff
     /**
      * Checks if the given token scope contains a single or multiple token codes/types.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param array<string|int>|string|int $search
-     * @param int $start
-     * @param int $end
-     * @param bool $skipNested
-     *
-     * @return bool
      */
     protected function contains(File $phpcsFile, $search, int $start, int $end, bool $skipNested = true): bool
     {
@@ -250,12 +195,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * Checks if the given token scope requires brackets when used standalone.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $openingBraceIndex
-     * @param int $closingBraceIndex
-     *
-     * @return bool
      */
     protected function needsBrackets(File $phpcsFile, int $openingBraceIndex, int $closingBraceIndex): bool
     {
@@ -292,9 +231,6 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return int|null Stackpointer value of docblock end tag, or null if cannot be found
      */
     protected function findRelatedDocBlock(File $phpCsFile, int $stackPointer): ?int
@@ -322,13 +258,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     * @param int $count
-     *
-     * @return void
-     */
     protected function outdent(File $phpcsFile, int $index, int $count = 1): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -337,13 +266,6 @@ abstract class AbstractSprykerSniff implements Sniff
         $phpcsFile->fixer->replaceToken($index, $this->strReplaceOnce($char, '', $tokens[$index]['content']));
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     * @param int $count
-     *
-     * @return void
-     */
     protected function indent(File $phpcsFile, int $index, int $count = 1): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -351,13 +273,6 @@ abstract class AbstractSprykerSniff implements Sniff
         $phpcsFile->fixer->replaceToken($index, $this->strReplaceOnce("\t", "\t\t", $tokens[$index]['content']));
     }
 
-    /**
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
-     *
-     * @return string
-     */
     protected function strReplaceOnce(string $search, string $replace, string $subject): string
     {
         $pos = strpos($subject, $search);
@@ -368,12 +283,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return substr($subject, 0, $pos) . $replace . substr($subject, $pos + strlen($search));
     }
 
-    /**
-     * @param string $content
-     * @param bool $correctLength
-     *
-     * @return string
-     */
     protected function getIndentationCharacter(string $content, bool $correctLength = false): string
     {
         if (strpos($content, "\n")) {
@@ -397,12 +306,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return $char;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $prevIndex
-     *
-     * @return string
-     */
     protected function getIndentationWhitespace(File $phpcsFile, int $prevIndex): string
     {
         $tokens = $phpcsFile->getTokens();
@@ -418,9 +321,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $index
-     *
-     * @return int
      */
     protected function getFirstTokenOfLine(array $tokens, int $index): int
     {
@@ -436,9 +336,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $index
-     *
-     * @return int
      */
     protected function getLastTokenOfLine(array $tokens, int $index): int
     {
@@ -453,11 +350,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPointer
-     *
-     * @return bool
      */
     protected function isMarkedAsDeprecated(File $phpCsFile, array $tokens, int $stackPointer): bool
     {
@@ -480,11 +373,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPointer
-     *
-     * @return bool
      */
     protected function isMarkedDeprecatedInDocBlock(File $phpCsFile, array $tokens, int $stackPointer): bool
     {
@@ -508,9 +397,6 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<string>
      */
     protected function getDocBlockReturnTypes(File $phpCsFile, int $stackPointer): array
@@ -534,12 +420,6 @@ abstract class AbstractSprykerSniff implements Sniff
         return $returnTypes;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $fileDocBlockStartPosition
-     *
-     * @return void
-     */
     protected function assertNewlineBefore(File $phpCsFile, int $fileDocBlockStartPosition): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -570,12 +450,7 @@ abstract class AbstractSprykerSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
-     *
-     * @return int
      */
     protected function getMethodSignatureLength(File $phpcsFile, int $stackPtr): int
     {
@@ -597,10 +472,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $firstPosition
-     * @param int $secondPosition
-     *
-     * @return bool
      */
     protected function areTokensOnTheSameLine(array $tokens, int $firstPosition, int $secondPosition): bool
     {
@@ -609,9 +480,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPtr
-     *
-     * @return int
      */
     protected function getMethodSingleLineSignatureLength(array $tokens, int $stackPtr): int
     {
@@ -622,9 +490,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $position
-     *
-     * @return int
      */
     protected function getLineEndingPosition(array $tokens, int $position): int
     {
@@ -637,11 +502,8 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPtr
      * @param array<string, mixed> $methodProperties
      * @param array<array<string, mixed>> $methodParameters
-     *
-     * @return int
      */
     protected function getMethodSignatureMultilineLength(
         array $tokens,
@@ -677,8 +539,6 @@ abstract class AbstractSprykerSniff implements Sniff
 
     /**
      * @param array<string, mixed> $methodParameter
-     *
-     * @return int
      */
     protected function getParameterTotalLength(array $methodParameter): int
     {

--- a/Spryker/Sniffs/Arrays/DisallowImplicitArrayCreationSniff.php
+++ b/Spryker/Sniffs/Arrays/DisallowImplicitArrayCreationSniff.php
@@ -29,11 +29,6 @@ class DisallowImplicitArrayCreationSniff extends SlevomatDisallowImplicitArrayCr
         parent::process($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param string $fileName
-     *
-     * @return bool
-     */
     protected function hasLegacyImplicitCreation(string $fileName): bool
     {
         if (strpos($fileName, DIRECTORY_SEPARATOR . 'config_') !== false || strpos($fileName, DIRECTORY_SEPARATOR . 'config.') !== false) {

--- a/Spryker/Sniffs/Classes/MethodArgumentDefaultValueSniff.php
+++ b/Spryker/Sniffs/Classes/MethodArgumentDefaultValueSniff.php
@@ -73,13 +73,6 @@ class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $startIndex
-     * @param int $endIndex
-     *
-     * @return int|null
-     */
     protected function getLastNonDefaultArgumentIndex(File $phpcsFile, int $startIndex, int $endIndex): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -106,12 +99,6 @@ class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $variableIndex
-     *
-     * @return bool
-     */
     protected function isEllipsis(File $phpcsFile, int $variableIndex): bool
     {
         $tokens = $phpcsFile->getTokens();
@@ -124,13 +111,6 @@ class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
         return $this->isGivenKind(T_ELLIPSIS, $tokens[$prevIndex]);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $startIndex
-     * @param int $endIndex
-     *
-     * @return void
-     */
     protected function removeDefaultArgument(File $phpcsFile, int $startIndex, int $endIndex): void
     {
         $this->clearWhitespacesBeforeIndex($phpcsFile, $startIndex);
@@ -140,10 +120,7 @@ class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $index Index of "="
-     *
-     * @return bool
      */
     protected function isTypehintedNullableVariable(File $phpcsFile, int $index): bool
     {
@@ -175,12 +152,6 @@ class MethodArgumentDefaultValueSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return void
-     */
     protected function clearWhitespacesBeforeIndex(File $phpcsFile, int $index): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/Classes/MethodTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/MethodTypeHintSniff.php
@@ -76,11 +76,6 @@ class MethodTypeHintSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->replaceToken($startIndex, 'self');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getCurrentClassName(File $phpCsFile): string
     {
         $fullClassName = parent::getClassName($phpCsFile);

--- a/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/Spryker/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -77,12 +77,6 @@ class ReturnTypeHintSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isChainingMethod(File $phpCsFile, int $stackPointer): bool
     {
         $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);
@@ -120,12 +114,6 @@ class ReturnTypeHintSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function assertNotThisOrStatic(File $phpCsFile, int $stackPointer): void
     {
         $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $stackPointer);

--- a/Spryker/Sniffs/Classes/SelfAccessorSniff.php
+++ b/Spryker/Sniffs/Classes/SelfAccessorSniff.php
@@ -70,11 +70,6 @@ class SelfAccessorSniff extends AbstractSprykerSniff
 
     /**
      * Checks casing of self (SELF, ...).
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
      */
     protected function checkSelf(File $phpcsFile, int $stackPtr): void
     {
@@ -91,13 +86,6 @@ class SelfAccessorSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $i
-     * @param string $name
-     *
-     * @return void
-     */
     protected function checkNew(File $phpcsFile, int $i, string $name): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -114,13 +102,6 @@ class SelfAccessorSniff extends AbstractSprykerSniff
         $this->fixNameToSelf($phpcsFile, $nextIndex, $name);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     * @param string $name
-     *
-     * @return void
-     */
     protected function fixNameToSelf(File $phpcsFile, int $index, string $name): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -140,13 +121,6 @@ class SelfAccessorSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $i
-     * @param string $name
-     *
-     * @return void
-     */
     protected function checkDoubleColon(File $phpcsFile, int $i, string $name): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
+++ b/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniff.php
@@ -38,10 +38,7 @@ use SlevomatCodingStandard\Helpers\TypeHintHelper;
  */
 class DisallowArrayTypeHintSyntaxSniff implements Sniff
 {
-    /**
-     * @var string
-     */
-    public const CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX = 'DisallowedArrayTypeHintSyntax';
+    public const string CODE_DISALLOWED_ARRAY_TYPE_HINT_SYNTAX = 'DisallowedArrayTypeHintSyntax';
 
     /**
      * @var array<string>
@@ -163,13 +160,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param \SlevomatCodingStandard\Helpers\Annotation $annotation
-     * @param string $fixedAnnotation
-     *
-     * @return void
-     */
     protected function fixAnnotation(File $phpcsFile, Annotation $annotation, string $fixedAnnotation): void
     {
         $parameterName = $annotation->getNode()->value->parameterName ?? '';
@@ -190,8 +180,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
     }
 
     /**
-     * @param \PHPStan\PhpDocParser\Ast\Node $node
-     *
      * @return list<\PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode>
      */
     public function getArrayTypeNodes(Node $node): array
@@ -206,11 +194,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                  */
                 private $nodes = [];
 
-                /**
-                 * @param \PHPStan\PhpDocParser\Ast\Node $node
-                 *
-                 * @return int|null
-                 */
                 public function enterNode(Node $node): ?int
                 {
                     if ($node instanceof ArrayTypeNode) {
@@ -224,9 +207,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
                     return null;
                 }
 
-                /**
-                 * @return void
-                 */
                 public function cleanNodes(): void
                 {
                     $this->nodes = [];
@@ -253,11 +233,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return $visitor->getNodes();
     }
 
-    /**
-     * @param \PHPStan\PhpDocParser\Ast\Type\TypeNode $node
-     *
-     * @return \PHPStan\PhpDocParser\Ast\Type\TypeNode
-     */
     protected function fixArrayNode(TypeNode $node): TypeNode
     {
         if (!$node instanceof ArrayTypeNode) {
@@ -268,10 +243,7 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
     }
 
     /**
-     * @param \PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode $arrayTypeNode
      * @param array<\PHPStan\PhpDocParser\Ast\Type\UnionTypeNode> $unionTypeNodes
-     *
-     * @return \PHPStan\PhpDocParser\Ast\Type\UnionTypeNode|null
      */
     protected function findUnionTypeThatContainsArrayType(ArrayTypeNode $arrayTypeNode, array $unionTypeNodes): ?UnionTypeNode
     {
@@ -284,14 +256,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $docCommentOpenPointer
-     * @param \PHPStan\PhpDocParser\Ast\Type\TypeNode $typeNode
-     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode $annotationValue
-     *
-     * @return string|null
-     */
     protected function findGenericIdentifier(
         File $phpcsFile,
         int $docCommentOpenPointer,
@@ -352,11 +316,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return null;
     }
 
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
     protected function isTraversableType(string $type): bool
     {
         return TypeHintHelper::isSimpleIterableTypeHint($type) || array_key_exists($type, $this->getNormalizedTraversableTypeHints());
@@ -378,11 +337,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return $this->normalizedTraversableTypeHints;
     }
 
-    /**
-     * @param \SlevomatCodingStandard\Helpers\Annotation $annotation
-     *
-     * @return bool
-     */
     protected function isGenericObjectCollection(Annotation $annotation): bool
     {
         $arrayTypeNodes = $this->getArrayTypeNodes($annotation->getValue());
@@ -402,11 +356,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return false;
     }
 
-    /**
-     * @param \PHPStan\PhpDocParser\Ast\Type\UnionTypeNode $unionTypeNode
-     *
-     * @return bool
-     */
     protected function isUnionTypeGenericObjectCollection(UnionTypeNode $unionTypeNode): bool
     {
         return $this->hasGenericObject($unionTypeNode->types)
@@ -417,8 +366,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
      * These generic object collections are not yet understood by IDEs like PHPStorm.
      *
      * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types
-     *
-     * @return bool
      */
     protected function hasGenericObject(array $types): bool
     {
@@ -435,11 +382,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return false;
     }
 
-    /**
-     * @param \PHPStan\PhpDocParser\Ast\Type\TypeNode $typeNode
-     *
-     * @return bool
-     */
     protected function isGenericObject(TypeNode $typeNode): bool
     {
         return $typeNode instanceof IdentifierTypeNode && strpos((string)$typeNode, '\\') === 0;
@@ -447,8 +389,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
 
     /**
      * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types
-     *
-     * @return bool
      */
     protected function containsArrayTypeNode(array $types): bool
     {
@@ -465,11 +405,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         return false;
     }
 
-    /**
-     * @param \PHPStan\PhpDocParser\Ast\Type\TypeNode $typeNode
-     *
-     * @return bool
-     */
     protected function isArrayTypeNode(TypeNode $typeNode): bool
     {
         return $typeNode instanceof ArrayTypeNode &&
@@ -477,13 +412,7 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param \SlevomatCodingStandard\Helpers\Annotation $annotation
-     * @param int $docCommentOpenPointer
-     * @param \PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode $typeNode
      * @param array<\PHPStan\PhpDocParser\Ast\Type\UnionTypeNode> $unionTypeNodes
-     *
-     * @return void
      */
     protected function fixGenericObjectCollection(
         File $phpcsFile,
@@ -546,11 +475,6 @@ class DisallowArrayTypeHintSyntaxSniff implements Sniff
         $this->fixAnnotation($phpcsFile, $annotation, $fixedType);
     }
 
-    /**
-     * @param \PHPStan\PhpDocParser\Ast\Type\TypeNode $typeNode
-     *
-     * @return string
-     */
     protected function convertTypeToString(TypeNode $typeNode): string
     {
         if ($typeNode instanceof ArrayTypeNode) {

--- a/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockApiAnnotationSniff.php
@@ -15,15 +15,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractApiClassDetectionSprykerSniff;
  */
 class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const INHERIT_DOC = '{@inheritDoc}';
+    protected const string INHERIT_DOC = '{@inheritDoc}';
 
-    /**
-     * @var string
-     */
-    protected const SPECIFICATION_TAG = 'Specification';
+    protected const string SPECIFICATION_TAG = 'Specification';
 
     /**
      * @inheritDoc
@@ -51,12 +45,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         $this->assertSpecification($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return int|null
-     */
     protected function findApiAnnotationIndex(File $phpCsFile, int $stackPointer): ?int
     {
         $docCommentOpenerPosition = $this->getDocOpenerPosition($phpCsFile, $stackPointer);
@@ -80,13 +68,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string|null $apiClass
-     *
-     * @return void
-     */
     protected function assertApiAnnotation(File $phpCsFile, int $stackPointer, ?string $apiClass): void
     {
         $apiAnnotationIndex = $this->findApiAnnotationIndex($phpCsFile, $stackPointer);
@@ -126,12 +107,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function assertNoApiTag(File $phpCsFile, int $stackPointer): void
     {
         $apiIndex = $this->findApiAnnotationIndex($phpCsFile, $stackPointer);
@@ -209,12 +184,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isInterface(File $phpCsFile, int $stackPointer): bool
     {
         $interfaceIndex = $phpCsFile->findPrevious(T_INTERFACE, $stackPointer);
@@ -225,12 +194,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isConstructor(File $phpCsFile, int $stackPointer): bool
     {
         $methodNameIndex = $phpCsFile->findNext(T_STRING, $stackPointer);
@@ -241,11 +204,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
 
     /**
      * Asserts that "Specification:" is used for interface, Plugin or Config, and must not be used for concrete class.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
      */
     protected function assertSpecification(File $phpCsFile, int $stackPointer): void
     {
@@ -275,23 +233,11 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     public function assertSpecificationAllowed(File $phpCsFile, int $stackPointer): void
     {
         $this->validateSpecification($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     public function assertSpecificationRequired(File $phpCsFile, int $stackPointer): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -306,12 +252,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         );
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return int|null
-     */
     public function validateSpecification(File $phpCsFile, int $stackPointer): ?int
     {
         $tokens = $phpCsFile->getTokens();
@@ -339,12 +279,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         return $specificationPosition;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     public function assertSpecificationFormat(File $phpCsFile, int $stackPointer): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -355,12 +289,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         $this->addTypoInSpecificationTagFixableError($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     public function addTypoInSpecificationTagFixableError(File $phpCsFile, int $stackPointer): void
     {
         $tokenContent = $phpCsFile->getTokens()[$stackPointer]['content'];
@@ -372,13 +300,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $line
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     public function addWrongSpecificationTagIndentationFixableError(File $phpCsFile, int $line, int $stackPointer): void
     {
         $fix = $phpCsFile->addFixableError(
@@ -393,12 +314,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     public function assertSpecificationForbidden(File $phpCsFile, int $stackPointer): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -412,23 +327,11 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     public function specificationRequiredClass(File $phpCsFile, int $stackPointer): bool
     {
         return $this->isInterface($phpCsFile, $stackPointer) && $this->sprykerApiClass($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     public function specificationAllowedClass(File $phpCsFile, int $stackPointer): bool
     {
         $namespace = $this->extractNamespace($phpCsFile, $stackPointer);
@@ -438,12 +341,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
             $this->isPlugin($namespace, $name);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     public function specificationForbiddenClass(File $phpCsFile, int $stackPointer): bool
     {
         $namespace = $this->extractNamespace($phpCsFile, $stackPointer);
@@ -455,12 +352,7 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
     }
 
     /**
-     * @param string $content
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $beginRange
-     * @param int $endRange
-     *
-     * @return int|null
      */
     protected function getContentPositionInRange(
         string $content,
@@ -479,23 +371,11 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return int|null
-     */
     protected function getDocOpenerPosition(File $phpCsFile, int $stackPointer): ?int
     {
         return $phpCsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPointer) ?: null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return int|null
-     */
     protected function getDocClosingPosition(File $phpCsFile, int $stackPointer): ?int
     {
         $docCommentOpenerPosition = $this->getDocOpenerPosition($phpCsFile, $stackPointer);
@@ -507,12 +387,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
         return $tokens[$docCommentOpenerPosition]['comment_closer'] ?? null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function assertInheritDocTag(File $phpCsFile, int $stackPointer): void
     {
         $docCommentOpenerPosition = $this->getDocOpenerPosition($phpCsFile, $stackPointer);
@@ -568,9 +442,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $currentIndex
-     *
-     * @return int
      */
     protected function lastTokenOnLine(array $tokens, int $currentIndex): int
     {
@@ -584,9 +455,6 @@ class DocBlockApiAnnotationSniff extends AbstractApiClassDetectionSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $currentIndex
-     *
-     * @return int
      */
     protected function firstTokenOnLine(array $tokens, int $currentIndex): int
     {

--- a/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockConstSniff.php
@@ -162,12 +162,6 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string|null
-     */
     protected function findDefaultValueType(File $phpCsFile, int $stackPointer): ?string
     {
         $tokens = $phpCsFile->getTokens();
@@ -192,8 +186,6 @@ class DocBlockConstSniff extends AbstractSprykerSniff
 
     /**
      * @param array<string, mixed> $token
-     *
-     * @return string|null
      */
     protected function detectType(array $token): ?string
     {
@@ -224,14 +216,6 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockEndIndex
-     * @param int $docBlockStartIndex
-     * @param string|null $defaultValueType
-     *
-     * @return void
-     */
     protected function handleMissingVar(
         File $phpCsFile,
         int $docBlockEndIndex,
@@ -277,13 +261,6 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $varIndex
-     * @param string|null $defaultValueType
-     *
-     * @return void
-     */
     protected function handleMissingVarType(File $phpCsFile, int $varIndex, ?string $defaultValueType): void
     {
         $error = 'Doc Block type for property annotation @var missing';
@@ -308,13 +285,6 @@ class DocBlockConstSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $defaultValueType
-     *
-     * @return void
-     */
     protected function addDocBlock(File $phpCsFile, int $stackPointer, string $defaultValueType): void
     {
         if ($defaultValueType === 'false') {

--- a/Spryker/Sniffs/Commenting/DocBlockInheritSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockInheritSniff.php
@@ -21,15 +21,9 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
     use CommentingTrait;
     use SignatureTrait;
 
-    /**
-     * @var string
-     */
-    protected const INHERIT_DOC = '{@inheritDoc}';
+    protected const string INHERIT_DOC = '{@inheritDoc}';
 
-    /**
-     * @var string
-     */
-    protected const INHERIT_DOC_INVALID = '{inheritDoc}';
+    protected const string INHERIT_DOC_INVALID = '{inheritDoc}';
 
     /**
      * @inheritDoc
@@ -54,13 +48,6 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
         $this->assertOrder($phpcsFile, $stackPtr, $closingTagIndex);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $openingTagIndex
-     * @param int $closingTagIndex
-     *
-     * @return void
-     */
     protected function assertType(File $phpcsFile, int $openingTagIndex, int $closingTagIndex): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -94,13 +81,6 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $openingTagIndex
-     * @param int $closingTagIndex
-     *
-     * @return void
-     */
     protected function assertOrder(File $phpcsFile, int $openingTagIndex, int $closingTagIndex): void
     {
         $inheritDocIndex = $this->getInheritDocIndex($phpcsFile, $openingTagIndex, $closingTagIndex);
@@ -145,13 +125,6 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $openingTagIndex
-     * @param int $closingTagIndex
-     *
-     * @return int|null
-     */
     protected function getInheritDocIndex(File $phpcsFile, int $openingTagIndex, int $closingTagIndex): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -169,13 +142,6 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $openingTagIndex
-     * @param int $closingTagIndex
-     *
-     * @return int|null
-     */
     protected function getFirstTagIndex(File $phpcsFile, int $openingTagIndex, int $closingTagIndex): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -191,12 +157,6 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return void
-     */
     protected function assertCasing(File $phpcsFile, int $index): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -219,14 +179,6 @@ class DocBlockInheritSniff extends AbstractApiClassDetectionSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $inheritDocIndex
-     * @param int $closingTagIndex
-     * @param int|null $firstTagIndex
-     *
-     * @return void
-     */
     protected function assertNoFollowingTextForCoreClasses(File $phpcsFile, int $inheritDocIndex, int $closingTagIndex, ?int $firstTagIndex): void
     {
         if ($firstTagIndex) {

--- a/Spryker/Sniffs/Commenting/DocBlockNoEmptySniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockNoEmptySniff.php
@@ -42,13 +42,6 @@ class DocBlockNoEmptySniff extends AbstractSprykerSniff
         $this->assertNoEmptyTag($phpcsFile, $stackPtr, $endIndex);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param int $endIndex
-     *
-     * @return void
-     */
     protected function assertNonEmptyDocBlock(File $phpcsFile, int $stackPtr, int $endIndex): void
     {
         $nextIndex = $phpcsFile->findNext([T_WHITESPACE, T_DOC_COMMENT_WHITESPACE, T_DOC_COMMENT_STAR], $stackPtr + 1, $endIndex - 1, true);
@@ -64,13 +57,6 @@ class DocBlockNoEmptySniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param int $endIndex
-     *
-     * @return void
-     */
     protected function assertNoEmptyTag(File $phpcsFile, int $stackPtr, int $endIndex): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DocBlockNoInlineAlignmentSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockNoInlineAlignmentSniff.php
@@ -41,12 +41,6 @@ class DocBlockNoInlineAlignmentSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkTag(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -73,12 +67,6 @@ class DocBlockNoInlineAlignmentSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkDescription(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -197,10 +197,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param string $type
      * @param array<string> $parts
-     *
-     * @return bool
      */
     protected function containsType(string $type, array $parts): bool
     {
@@ -221,10 +218,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param string $type
      * @param array<string> $parts
-     *
-     * @return bool
      */
     protected function isPrimitiveGenerics(string $type, array $parts): bool
     {
@@ -243,10 +237,7 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param string $type
      * @param array<string> $parts
-     *
-     * @return bool
      */
     protected function isClassString(string $type, array $parts): bool
     {

--- a/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockParamSniff.php
@@ -35,7 +35,7 @@ class DocBlockParamSniff extends AbstractSprykerSniff
      *
      * @var array<string>
      */
-    protected const LOSSY_TYPE_HINTS = ['array', 'iterable'];
+    protected const array LOSSY_TYPE_HINTS = ['array', 'iterable'];
 
     /**
      * @inheritDoc
@@ -157,10 +157,6 @@ class DocBlockParamSniff extends AbstractSprykerSniff
     /**
      * A union type expresses the full type only when none of its members is lossy: `array|string`
      * still hides the array element type and shape, so it keeps requiring a `@param`.
-     *
-     * @param string $typeHint
-     *
-     * @return bool
      */
     protected function hasLossyType(string $typeHint): bool
     {
@@ -173,13 +169,6 @@ class DocBlockParamSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return void
-     */
     protected function assertNoParams(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): void
     {
         $tokens = $phpCsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockPipeSpacingSniff.php
@@ -86,12 +86,6 @@ class DocBlockPipeSpacingSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function isInlineDocBlock(File $phpcsFile, int $stackPtr): bool
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullSniff.php
@@ -100,13 +100,8 @@ class DocBlockReturnNullSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $classNameIndex
      * @param array<string> $returnTypes
      * @param array<string> $parts
-     * @param string $appendix
-     *
-     * @return void
      */
     protected function fixParts(File $phpCsFile, int $classNameIndex, array $returnTypes, array $parts, string $appendix): void
     {
@@ -133,9 +128,6 @@ class DocBlockReturnNullSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return int|null Stackpointer value of docblock end tag, or null if cannot be found
      */
     protected function findRelatedDocBlock(File $phpCsFile, int $stackPointer): ?int
@@ -157,9 +149,6 @@ class DocBlockReturnNullSniff implements Sniff
 
     /**
      * For right now we only try to detect basic types.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $index
      *
      * @return array<string>
      */

--- a/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniff.php
@@ -80,9 +80,6 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<string>|null
      */
     protected function parseDocBlockReturnTypes(File $phpCsFile, int $stackPointer): ?array
@@ -99,13 +96,6 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
         return $this->valueNodeParts($valueNode);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return int|null
-     */
     protected function findDocBlockReturn(File $phpcsFile, int $docBlockStartIndex, int $docBlockEndIndex): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -125,11 +115,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $docBlockReturnTypes
-     *
-     * @return void
      */
     public function assertNotNullableReturnType(File $phpCsFile, int $stackPointer, array $docBlockReturnTypes): void
     {
@@ -151,11 +137,7 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $docBlockReturnTypes
-     *
-     * @return void
      */
     public function assertRequiredNullableReturnType(
         File $phpCsFile,
@@ -179,12 +161,6 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
         $this->addNullToDocBlockReturnType($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function addNullToDocBlockReturnType(File $phpCsFile, int $stackPointer): void
     {
         $returnTypeToken = $this->getDocBlockReturnTypeToken($phpCsFile, $stackPointer);
@@ -198,12 +174,6 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function removeNullFromDocBlockReturnType(File $phpCsFile, int $stackPointer): void
     {
         $returnTypesToken = $this->getDocBlockReturnTypeToken($phpCsFile, $stackPointer);
@@ -222,9 +192,6 @@ class DocBlockReturnNullableTypeSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @throws \RuntimeException
      *
      * @return array<string, mixed>

--- a/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -85,13 +85,8 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $classNameIndex
      * @param array<string> $parts
      * @param array<string> $returnTypes
-     * @param string $appendix
-     *
-     * @return void
      */
     protected function assertCorrectDocBlockParts(
         File $phpCsFile,
@@ -130,9 +125,6 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return int|null Stackpointer value of docblock end tag, or null if cannot be found
      */
     protected function findRelatedDocBlock(File $phpCsFile, int $stackPointer): ?int
@@ -152,12 +144,6 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isStaticMethod(File $phpCsFile, int $stackPointer): bool
     {
         $tokens = $phpCsFile->getTokens();
@@ -172,13 +158,8 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $classNameIndex
      * @param array<string> $parts
-     * @param string $appendix
      * @param array<string> $returnTypes
-     *
-     * @return void
      */
     protected function fixClassToThis(
         File $phpCsFile,
@@ -222,9 +203,6 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
 
     /**
      * We want to skip for static or other non chainable use cases.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      *
      * @return array<string>
      */
@@ -284,12 +262,8 @@ class DocBlockReturnSelfSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $parts
      * @param array<string> $returnTypes
-     *
-     * @return void
      */
     protected function assertChainableReturnType(
         File $phpCsFile,

--- a/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnTagSniff.php
@@ -50,13 +50,6 @@ class DocBlockReturnTagSniff extends AbstractSprykerSniff
         $this->assertDescription($phpcsFile, $nextIndex, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $nextIndex
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function assertDescription(File $phpcsFile, int $nextIndex, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniff.php
@@ -110,12 +110,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         $this->addReturnAnnotation($phpcsFile, $docBlockStartIndex, $docBlockEndIndex, $returnType);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return void
-     */
     protected function checkConstructorAndDestructor(File $phpcsFile, int $index): void
     {
         $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $index);
@@ -144,13 +138,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return int|null
-     */
     protected function findDocBlockReturn(File $phpcsFile, int $docBlockStartIndex, int $docBlockEndIndex): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -169,14 +156,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     * @param string $returnType
-     *
-     * @return void
-     */
     protected function addReturnAnnotation(
         File $phpcsFile,
         int $docBlockStartIndex,
@@ -199,11 +178,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
 
     /**
      * For right now we only try to detect void inside function/method.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return string|null
      */
     protected function detectReturnTypeVoid(File $phpcsFile, int $index): ?string
     {
@@ -238,14 +212,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         return $type;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $pointer
-     * @param int $docBlockReturnIndex
-     * @param string|null $returnType
-     *
-     * @return void
-     */
     protected function assertExisting(
         File $phpcsFile,
         int $pointer,
@@ -276,13 +242,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         $phpcsFile->addError('Method is void, but doc block states otherwise.', $docBlockReturnIndex + 2, 'InvalidVoidBody');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param int $docBlockReturnIndex
-     *
-     * @return void
-     */
     protected function assertTypeHint(File $phpcsFile, int $stackPtr, int $docBlockReturnIndex): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -328,11 +287,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         $phpcsFile->addError($message, $typeHintIndex, 'ReturnTypeMismatch');
     }
 
-    /**
-     * @param string $documentedReturnType
-     *
-     * @return bool
-     */
     protected function documentedTypesContainFuzzyVoid(string $documentedReturnType): bool
     {
         $types = explode('|', $documentedReturnType);
@@ -340,12 +294,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
         return in_array('null', $types, true);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $pointer
-     *
-     * @return bool
-     */
     protected function bodyContainsYield(File $phpcsFile, int $pointer): bool
     {
         $tokens = $phpcsFile->getTokens();
@@ -364,9 +312,6 @@ class DocBlockReturnVoidSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $docBlockReturnIndex
-     *
-     * @return string
      */
     protected function documentedReturnType(array $tokens, int $docBlockReturnIndex): string
     {

--- a/Spryker/Sniffs/Commenting/DocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockSniff.php
@@ -76,13 +76,6 @@ class DocBlockSniff extends AbstractSprykerSniff
         $this->addDocBlock($phpcsFile, $stackPtr, $returnType);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     * @param string $returnType
-     *
-     * @return void
-     */
     protected function addDocBlock(File $phpcsFile, int $index, string $returnType): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -111,12 +104,6 @@ class DocBlockSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkConstructorAndDestructor(File $phpcsFile, int $stackPtr): void
     {
         $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $stackPtr);
@@ -133,13 +120,6 @@ class DocBlockSniff extends AbstractSprykerSniff
         $phpcsFile->addError('Missing doc block for method', $stackPtr, 'ConstructDesctructMissingDocBlock');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return int|null
-     */
     protected function findDocBlockReturn(File $phpcsFile, int $docBlockStartIndex, int $docBlockEndIndex): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -160,11 +140,6 @@ class DocBlockSniff extends AbstractSprykerSniff
 
     /**
      * For right now we only try to detect void.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return string|null
      */
     protected function detectReturnTypeVoid(File $phpcsFile, int $index): ?string
     {

--- a/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagGroupingSniff.php
@@ -58,13 +58,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
         $this->checkAnnotationTagGrouping($phpCsFile, $docBlockStartIndex, $docBlockEndIndex);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return void
-     */
     protected function checkFirstAnnotationTag(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -120,13 +113,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return void
-     */
     protected function checkLastAnnotationTag(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -158,13 +144,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $nextIndex
-     *
-     * @return void
-     */
     protected function checkBeginningOfDocBlock(File $phpCsFile, int $docBlockStartIndex, int $nextIndex): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -191,13 +170,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
-     * @return void
-     */
     protected function checkAnnotationTagGrouping(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): void
     {
         $tags = $this->readTags($phpCsFile, $docBlockStartIndex, $docBlockEndIndex);
@@ -222,10 +194,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function readTags(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): array
@@ -260,9 +228,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $index
-     *
-     * @return int
      */
     protected function getEndIndex(array $tokens, int $index): int
     {
@@ -284,10 +249,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $start
-     * @param int $end
-     *
-     * @return int
      */
     protected function getTagEndIndex(array $tokens, int $start, int $end): int
     {
@@ -304,10 +265,6 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $start
-     * @param int $end
-     *
-     * @return string
      */
     protected function getContent(array $tokens, int $start, int $end): string
     {
@@ -320,11 +277,8 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<string, mixed> $first
      * @param array<string, mixed> $second
-     *
-     * @return void
      */
     protected function assertNoSpacing(File $phpCsFile, array $first, array $second): void
     {
@@ -359,11 +313,8 @@ class DocBlockTagGroupingSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<string, mixed> $first
      * @param array<string, mixed> $second
-     *
-     * @return void
      */
     protected function assertSpacing(File $phpCsFile, array $first, array $second): void
     {

--- a/Spryker/Sniffs/Commenting/DocBlockTagIterableSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagIterableSniff.php
@@ -55,13 +55,6 @@ class DocBlockTagIterableSniff implements Sniff
         $this->assertType($phpcsFile, $possibleTextIndex, $tag);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $tag
-     *
-     * @return void
-     */
     protected function assertType(File $phpcsFile, int $stackPtr, string $tag): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -104,11 +97,6 @@ class DocBlockTagIterableSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param string $definition
-     *
-     * @return string
-     */
     protected function assertDefinition(string $definition): string
     {
         return (string)preg_replace_callback('#,([^ ])#', function ($matches) {

--- a/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagOrderSniff.php
@@ -104,10 +104,6 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function readTags(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex): array
@@ -142,9 +138,6 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $index
-     *
-     * @return int
      */
     protected function getEndIndex(array $tokens, int $index): int
     {
@@ -166,10 +159,6 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $start
-     * @param int $end
-     *
-     * @return int
      */
     protected function getTagEndIndex(array $tokens, int $start, int $end): int
     {
@@ -186,10 +175,6 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $start
-     * @param int $end
-     *
-     * @return string
      */
     protected function getContent(array $tokens, int $start, int $end): string
     {
@@ -202,12 +187,7 @@ class DocBlockTagOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
      * @param array<int, array<string, mixed>> $tags
-     *
-     * @return void
      */
     protected function fixOrder(File $phpCsFile, int $docBlockStartIndex, int $docBlockEndIndex, array $tags): void
     {

--- a/Spryker/Sniffs/Commenting/DocBlockTagSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTagSniff.php
@@ -16,15 +16,9 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class DocBlockTagSniff implements Sniff
 {
-    /**
-     * @var string
-     */
-    protected const INHERIT_DOC_FULL = '@inheritDoc';
+    protected const string INHERIT_DOC_FULL = '@inheritDoc';
 
-    /**
-     * @var string
-     */
-    protected const INHERIT_DOC_FULL_INVALID = '@inheritdoc';
+    protected const string INHERIT_DOC_FULL_INVALID = '@inheritdoc';
 
     /**
      * @inheritDoc
@@ -60,14 +54,6 @@ class DocBlockTagSniff implements Sniff
         $this->assertInheritDocCasing($phpcsFile, $stackPtr, $tag, $description);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $tag
-     * @param string $description
-     *
-     * @return void
-     */
     protected function assertInheritDocCasing(File $phpcsFile, int $stackPtr, string $tag, string $description): void
     {
         if ($tag === static::INHERIT_DOC_FULL) {

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotation2Sniff.php
@@ -16,15 +16,9 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const ANNOTATION_START_TEXT = 'Auto-generated group annotations';
+    protected const string ANNOTATION_START_TEXT = 'Auto-generated group annotations';
 
-    /**
-     * @var string
-     */
-    protected const ANNOTATION_END_TEXT = 'Add your own group annotations below this line';
+    protected const string ANNOTATION_END_TEXT = 'Add your own group annotations below this line';
 
     /**
      * @inheritDoc
@@ -70,11 +64,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $expectedGroupAnnotations
-     *
-     * @return void
      */
     protected function fixGroupAnnotation(File $phpCsFile, int $stackPointer, array $expectedGroupAnnotations): void
     {
@@ -96,11 +86,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $expectedAnnotations
-     *
-     * @return void
      */
     protected function addCommentWithGroupAnnotation(
         File $phpCsFile,
@@ -133,11 +119,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentEndPosition
      * @param array<string> $namespaceParts
-     *
-     * @return void
      */
     protected function modifyExistingComment(File $phpCsFile, int $docCommentEndPosition, array $namespaceParts): void
     {
@@ -165,9 +147,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<string>
      */
     protected function getNamespaceParts(File $phpCsFile, int $stackPointer): array
@@ -185,12 +164,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
         return $parts;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getClassOrInterfaceName(File $phpCsFile, int $stackPointer): string
     {
         $classOrInterfacePosition = $phpCsFile->findPrevious([T_CLASS, T_INTERFACE], $stackPointer);
@@ -205,9 +178,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<int, string>
      */
     protected function getAnnotations(File $phpCsFile, int $stackPointer): array
@@ -240,7 +210,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<string> $namespaceParts
      *
      * @return array<string>
@@ -267,13 +236,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
         return array_map($callback, $expectedAnnotations);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentStartPosition
-     * @param int $firstDocCommentTagPosition
-     *
-     * @return int|null
-     */
     protected function findGroupTagPosition(
         File $phpCsFile,
         int $docCommentStartPosition,
@@ -297,12 +259,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentStartPosition
-     *
-     * @return int
-     */
     protected function getLastLineOfDocBlock(File $phpCsFile, int $docCommentStartPosition): int
     {
         $tokens = $phpCsFile->getTokens();
@@ -316,13 +272,7 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentStartPosition
-     * @param int $firstGroupTagPosition
-     *
      * @throws \Exception
-     *
-     * @return int
      */
     protected function getGroupTagPositionEnd(
         File $phpCsFile,
@@ -351,8 +301,6 @@ class DocBlockTestGroupAnnotation2Sniff extends AbstractSprykerSniff
     /**
      * @param array<string> $givenGroupAnnotationParts
      * @param array<string> $expectedGroupAnnotations
-     *
-     * @return bool
      */
     protected function containsExpectedGroupAnnotations(
         array $givenGroupAnnotationParts,

--- a/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTestGroupAnnotationSniff.php
@@ -53,11 +53,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $namespaceParts
-     *
-     * @return void
      */
     protected function fixGroupAnnotation(File $phpCsFile, int $stackPointer, array $namespaceParts): void
     {
@@ -79,11 +75,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
      * @param array<string> $namespaceParts
-     *
-     * @return void
      */
     protected function addCommentWithGroupAnnotation(File $phpCsFile, int $stackPointer, array $namespaceParts): void
     {
@@ -113,11 +105,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentEndPosition
      * @param array<string> $namespaceParts
-     *
-     * @return void
      */
     protected function modifyExistingComment(File $phpCsFile, int $docCommentEndPosition, array $namespaceParts): void
     {
@@ -150,9 +138,6 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<string>
      */
     protected function getNamespaceParts(File $phpCsFile, int $stackPointer): array
@@ -170,12 +155,6 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
         return $parts;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getClassOrInterfaceName(File $phpCsFile, int $stackPointer): string
     {
         $classOrInterfacePosition = $phpCsFile->findPrevious([T_CLASS, T_INTERFACE], $stackPointer);
@@ -188,9 +167,6 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<string>
      */
     protected function getGroupAnnotationParts(File $phpCsFile, int $stackPointer): array
@@ -217,13 +193,6 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
         return $parts;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentStartPosition
-     * @param int $firstDocCommentTagPosition
-     *
-     * @return int|null
-     */
     protected function findGroupTagPosition(
         File $phpCsFile,
         int $docCommentStartPosition,
@@ -247,12 +216,6 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentStartPosition
-     *
-     * @return int
-     */
     protected function getLastLineOfDocBlock(File $phpCsFile, int $docCommentStartPosition): int
     {
         $tokens = $phpCsFile->getTokens();
@@ -266,13 +229,7 @@ class DocBlockTestGroupAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docCommentStartPosition
-     * @param int $firstGroupTagPosition
-     *
      * @throws \Exception
-     *
-     * @return int
      */
     protected function getGroupTagPositionEnd(
         File $phpCsFile,

--- a/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -87,9 +87,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function extractExceptions(File $phpCsFile, int $stackPointer): array
@@ -160,9 +157,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function extractExceptionAnnotations(File $phpCsFile, int $docBlockStartIndex): array
@@ -213,9 +207,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $contentIndex
-     *
      * @return array<string, mixed>
      */
     protected function extractException(File $phpCsFile, int $contentIndex): array
@@ -245,12 +236,8 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<int, array<string, mixed>> $exceptions
      * @param array<int, array<string, mixed>> $annotations
-     * @param int $docBlockEndIndex
-     *
-     * @return void
      */
     protected function compareExceptionsAndAnnotations(
         File $phpCsFile,
@@ -331,8 +318,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
      * @param array<string, mixed> $annotation
      * @param array<int, array<string, mixed>> $exceptions
      * @param array<string, array<string, mixed>> $useStatements
-     *
-     * @return bool
      */
     protected function isInCode(array $annotation, array $exceptions, array $useStatements): bool
     {
@@ -350,8 +335,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     /**
      * @param array<string, mixed> $exception
      * @param array<int, array<string, mixed>> $annotations
-     *
-     * @return bool
      */
     protected function isInAnnotation(array $exception, array $annotations): bool
     {
@@ -364,12 +347,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $position
-     *
-     * @return void
-     */
     protected function removeLine(File $phpCsFile, int $position): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -382,13 +359,9 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<string, array<string, mixed>> $exceptions
-     * @param int $docBlockEndIndex
      *
      * @throws \Exception
-     *
-     * @return void
      */
     protected function addAnnotationLines(File $phpCsFile, array $exceptions, int $docBlockEndIndex): void
     {
@@ -415,9 +388,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $docBlockStartIndex
-     *
-     * @return int
      */
     protected function getThrowAnnotationIndex(array $tokens, int $docBlockStartIndex): int
     {
@@ -452,10 +422,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $scopeOpener
-     * @param int $scopeCloser
-     *
-     * @return bool
      */
     protected function containsComplexThrowToken(array $tokens, int $scopeOpener, int $scopeCloser): bool
     {
@@ -476,10 +442,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $scopeOpener
-     * @param int $scopeCloser
-     *
-     * @return bool
      */
     protected function containsThrowToken(array $tokens, int $scopeOpener, int $scopeCloser): bool
     {
@@ -494,12 +456,6 @@ class DocBlockThrowsSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     *
-     * @return bool
-     */
     protected function isApiMethod(File $phpCsFile, int $docBlockStartIndex): bool
     {
         $tokens = $phpCsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockTypeOrderSniff.php
@@ -63,10 +63,7 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
      * @param array<int, array<string, mixed>> $docBlockParams
-     *
-     * @return void
      */
     protected function assertOrder(File $phpCsFile, array $docBlockParams): void
     {
@@ -117,12 +114,6 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
         return $elements;
     }
 
-    /**
-     * @param string $a
-     * @param string $b
-     *
-     * @return int
-     */
     protected function compare(string $a, string $b): int
     {
         global $sortOrder;
@@ -144,8 +135,6 @@ class DocBlockTypeOrderSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
      *
      * @return array<int, array<string, mixed>>
      */

--- a/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/Spryker/Sniffs/Commenting/DocBlockVarSniff.php
@@ -145,12 +145,6 @@ class DocBlockVarSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string|null
-     */
     protected function findDefaultValueType(File $phpCsFile, int $stackPointer): ?string
     {
         $tokens = $phpCsFile->getTokens();
@@ -170,8 +164,6 @@ class DocBlockVarSniff extends AbstractSprykerSniff
 
     /**
      * @param array<string, mixed> $token
-     *
-     * @return string|null
      */
     protected function detectType(array $token): ?string
     {
@@ -202,14 +194,6 @@ class DocBlockVarSniff extends AbstractSprykerSniff
         return null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockEndIndex
-     * @param int $docBlockStartIndex
-     * @param string|null $defaultValueType
-     *
-     * @return void
-     */
     protected function handleMissingVar(
         File $phpCsFile,
         int $docBlockEndIndex,
@@ -246,13 +230,6 @@ class DocBlockVarSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $varIndex
-     * @param string|null $defaultValueType
-     *
-     * @return void
-     */
     protected function handleMissingVarType(File $phpCsFile, int $varIndex, ?string $defaultValueType): void
     {
         $error = 'Doc Block type for property annotation @var missing';

--- a/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FileDocBlockSniff.php
@@ -87,13 +87,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         $this->fixFileDocBlock($phpCsFile, $fileDocBlockPointer, $license);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $license
-     *
-     * @return void
-     */
     protected function addMissingFileDocBlock(File $phpCsFile, int $stackPointer, string $license): void
     {
         if (!$license) {
@@ -116,22 +109,11 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isIgnorableModule(File $phpCsFile): bool
     {
         return (in_array($this->getModule($phpCsFile), $this->ignorableModules, true));
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $fileDocBlockStartPointer
-     *
-     * @return bool
-     */
     protected function isOwnFileDocBlock(File $phpCsFile, int $fileDocBlockStartPointer): bool
     {
         $fileDockBlockLines = $this->getFileDocBlockLines($phpCsFile, $fileDocBlockStartPointer);
@@ -148,11 +130,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getLicense(File $phpCsFile): string
     {
         $customLicense = $this->findLicense($phpCsFile);
@@ -163,11 +140,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         return $customLicense === 'none' ? '' : $customLicense;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string|null
-     */
     protected function findLicense(File $phpCsFile): ?string
     {
         $currentPath = getcwd();
@@ -298,10 +270,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
 
     /**
      * Gets license header to be used. Returns `none` for no license header as custom license.
-     *
-     * @param string $path
-     *
-     * @return string
      */
     protected function findCustomLicense(string $path): string
     {
@@ -327,10 +295,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
 
     /**
      * Gets default license if the class file is a Spryker namespaced one.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
      */
     protected function getDefaultLicense(File $phpCsFile): string
     {
@@ -341,13 +305,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         return $this->buildLicense(static::$defaultLicense);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $fileDocBlockStartPosition
-     * @param string $license
-     *
-     * @return void
-     */
     protected function fixFileDocBlock(File $phpCsFile, int $fileDocBlockStartPosition, string $license): void
     {
         $fix = $phpCsFile->addFixableError('Wrong file doc block', $fileDocBlockStartPosition, 'FileDocBlockWrong');
@@ -366,12 +323,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return int|null
-     */
     protected function fileDocBlockPointer(File $phpCsFile, int $stackPointer): ?int
     {
         $fileDocBlockStartPosition = $phpCsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPointer);
@@ -379,12 +330,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         return $fileDocBlockStartPosition !== false ? $fileDocBlockStartPosition : null;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $fileDocBlockStartPosition
-     *
-     * @return void
-     */
     protected function clearFileDocBlock(File $phpCsFile, int $fileDocBlockStartPosition): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -396,9 +341,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int|null $fileDocBlockStartPosition
-     *
      * @return array<string>
      */
     protected function getFileDocBlockLines(File $phpCsFile, ?int $fileDocBlockStartPosition): array
@@ -417,12 +359,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
         return $result;
     }
 
-    /**
-     * @param string $currentLicense
-     * @param string $expectedLicense
-     *
-     * @return bool
-     */
     protected function isCorrectFileDocBlock(string $currentLicense, string $expectedLicense): bool
     {
         $currentLicense = str_replace(["\r\n", "\r"], "\n", $currentLicense);
@@ -433,8 +369,6 @@ class FileDocBlockSniff extends AbstractSprykerSniff
 
     /**
      * @param array<string> $licenseLines
-     *
-     * @return string
      */
     protected function buildLicense(array $licenseLines): string
     {

--- a/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -98,12 +98,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $classNameIndex
      * @param array<string> $classNames
-     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode $valueNode
-     *
-     * @return void
      */
     protected function fixClassNames(File $phpCsFile, int $classNameIndex, array $classNames, PhpDocTagValueNode $valueNode): void
     {
@@ -126,8 +121,6 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $classNameIndex
      * @param array<string> $classNames
      *
      * @return array<string>
@@ -174,12 +167,6 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
         return $result;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $className
-     *
-     * @return string|null
-     */
     protected function findUseStatementForClassName(File $phpCsFile, string $className): ?string
     {
         $useStatements = $this->parseUseStatements($phpCsFile);
@@ -195,12 +182,6 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
         return $useStatements[$className];
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $className
-     *
-     * @return string|null
-     */
     protected function findInSameNameSpace(File $phpCsFile, string $className): ?string
     {
         $currentNameSpace = $this->getNamespace($phpCsFile);
@@ -217,11 +198,6 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
         return '\\' . $currentNameSpace . '\\' . $className;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getNamespace(File $phpCsFile): string
     {
         $tokens = $phpCsFile->getTokens();
@@ -257,9 +233,6 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return int|null Stackpointer value of docblock end tag, or null if cannot be found
      */
     protected function findRelatedDocBlock(File $phpCsFile, int $stackPointer): ?int
@@ -280,8 +253,6 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
      * @return array<string>
      */
     protected function parseUseStatements(File $phpCsFile): array

--- a/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
+++ b/Spryker/Sniffs/Commenting/InlineDocBlockSniff.php
@@ -44,13 +44,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         $this->checkInlineComments($phpCsFile, $startIndex, $endIndex);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $startIndex
-     * @param int $endIndex
-     *
-     * @return void
-     */
     protected function fixDocCommentOpenTags(File $phpCsFile, int $startIndex, int $endIndex): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -78,13 +71,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $startIndex
-     * @param int $endIndex
-     *
-     * @return void
-     */
     protected function checkInlineComments(File $phpCsFile, int $startIndex, int $endIndex): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -147,11 +133,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param string $tag
-     *
-     * @return bool
-     */
     protected function isAllowedTag(string $tag): bool
     {
         if (strpos($tag, '@phpstan-') === 0 || strpos($tag, '@psalm-') === 0) {
@@ -163,11 +144,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $from
-     * @param int $to
-     * @param string $tagType
-     *
-     * @return int|null
      */
     protected function findTagIndex(array $tokens, int $from, int $to, string $tagType): ?int
     {
@@ -181,10 +157,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $contentIndex
-     * @param bool $isSingleLine
-     *
      * @return array<string>
      */
     protected function findErrors(File $phpCsFile, int $contentIndex, bool $isSingleLine): array
@@ -222,12 +194,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         return $errors;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $contentIndex
-     *
-     * @return bool
-     */
     protected function hasReturnAsFollowingToken(File $phpCsFile, int $contentIndex): bool
     {
         $nextIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $contentIndex + 1, null, true);
@@ -240,12 +206,6 @@ class InlineDocBlockSniff extends AbstractSprykerSniff
         return $tokens[$nextIndex]['code'] === T_RETURN;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $commentEndTagIndex
-     *
-     * @return bool
-     */
     protected function isNotInline(File $phpCsFile, int $commentEndTagIndex): bool
     {
         $tokens = $phpCsFile->getTokens();

--- a/Spryker/Sniffs/Commenting/SprykerAnnotationSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerAnnotationSniff.php
@@ -38,12 +38,6 @@ class SprykerAnnotationSniff extends AbstractSprykerSniff
         $this->checkAnnotations($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function checkAnnotations(File $phpCsFile, int $stackPointer): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -81,10 +75,6 @@ class SprykerAnnotationSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartIndex
-     * @param int $docBlockEndIndex
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function getFixableMethodAnnotations(
@@ -160,11 +150,6 @@ class SprykerAnnotationSniff extends AbstractSprykerSniff
         return $annotations;
     }
 
-    /**
-     * @param string $path
-     *
-     * @return string|null
-     */
     protected function findBasePath(string $path): ?string
     {
         preg_match('#^.+/(vendor|spryker)/.+/src/#', $path, $matches);
@@ -175,11 +160,6 @@ class SprykerAnnotationSniff extends AbstractSprykerSniff
         return rtrim($matches[0], DIRECTORY_SEPARATOR);
     }
 
-    /**
-     * @param string $class
-     *
-     * @return bool
-     */
     protected function isAbstract(string $class): bool
     {
         $classPieces = explode('\\', $class);

--- a/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
+++ b/Spryker/Sniffs/Commenting/SprykerConstantsSniff.php
@@ -15,10 +15,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class SprykerConstantsSniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const EXPLANATION_CONSTANTS_INTERFACE = 'Declares global environment configuration keys. Do not use it for other class constants.';
+    protected const string EXPLANATION_CONSTANTS_INTERFACE = 'Declares global environment configuration keys. Do not use it for other class constants.';
 
     /**
      * We must support class for now, as well - for BC.
@@ -44,12 +41,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         $this->checkConstantsInterface($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function checkConstantsInterface(File $phpCsFile, int $stackPointer): void
     {
         $docBlockEndIndex = $this->findDocBlock($phpCsFile, $stackPointer);
@@ -63,12 +54,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         $this->checkExistingDocBlock($phpCsFile, $docBlockEndIndex);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function addNewDocBlock(File $phpCsFile, int $stackPointer): void
     {
         $fix = $phpCsFile->addFixableError('Missing Constants interface doc block.', $stackPointer, 'DocBlockMissing');
@@ -90,12 +75,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockEndPosition
-     *
-     * @return void
-     */
     protected function checkExistingDocBlock(File $phpCsFile, int $docBlockEndPosition): void
     {
         if ($this->hasCorrectContent($phpCsFile, $docBlockEndPosition)) {
@@ -120,12 +99,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         $phpCsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isSprykerConstantsInterface(File $phpCsFile, int $stackPointer): bool
     {
         if (!$this->hasNamespace($phpCsFile, $stackPointer)) {
@@ -145,12 +118,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function hasNamespace(File $phpCsFile, int $stackPointer): bool
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $stackPointer);
@@ -161,12 +128,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getInterfaceNamespace(File $phpCsFile, int $stackPointer): string
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $stackPointer);
@@ -186,12 +147,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         return $namespace;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function findClassOrInterfaceName(File $phpCsFile, int $stackPointer): string
     {
         $classOrInterfaceNamePosition = $phpCsFile->findNext(T_STRING, $stackPointer);
@@ -200,9 +155,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return int|null Stack pointer value of docblock end tag, or null if cannot be found
      */
     protected function findDocBlock(File $phpCsFile, int $stackPointer): ?int
@@ -217,12 +169,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         return $index;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockEndPosition
-     *
-     * @return bool
-     */
     protected function hasCorrectContent(File $phpCsFile, int $docBlockEndPosition): bool
     {
         $tokens = $phpCsFile->getTokens();
@@ -244,12 +190,6 @@ class SprykerConstantsSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $docBlockStartPosition
-     *
-     * @return void
-     */
     protected function insertDocBlock(File $phpCsFile, int $docBlockStartPosition): void
     {
         $phpCsFile->fixer->addContent($docBlockStartPosition, '/**');

--- a/Spryker/Sniffs/Commenting/TypeHintSniff.php
+++ b/Spryker/Sniffs/Commenting/TypeHintSniff.php
@@ -241,8 +241,6 @@ class TypeHintSniff extends AbstractSprykerSniff
 
     /**
      * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types node types
-     *
-     * @return string
      */
     protected function getSortedTypeHint(array $types): string
     {
@@ -322,8 +320,6 @@ class TypeHintSniff extends AbstractSprykerSniff
      * Checks if it is an object collection of any type (\FQCN<type>).
      *
      * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types
-     *
-     * @return bool
      */
     protected function isObjectCollection(array $types): bool
     {
@@ -343,10 +339,6 @@ class TypeHintSniff extends AbstractSprykerSniff
     /**
      * We do not want to touch stan tags, as they are usually more accurate than normal tags.
      * Normal tags often need legacy syntax for IDEs to understand them.
-     *
-     * @param string $tag
-     *
-     * @return bool
      */
     protected function isStanTag(string $tag): bool
     {
@@ -354,12 +346,7 @@ class TypeHintSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param string $tag
-     * @param string|null $content
      * @param array<int> $commentTags
-     *
-     * @return bool
      */
     protected function isDuplicate(File $phpcsFile, string $tag, ?string $content, array $commentTags): bool
     {
@@ -386,12 +373,7 @@ class TypeHintSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param string $tag
-     * @param string|null $content
      * @param array<int> $commentTags
-     *
-     * @return int|null
      */
     protected function findMerchableTag(File $phpcsFile, string $tag, ?string $content, array $commentTags): ?int
     {

--- a/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/Spryker/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -44,12 +44,6 @@ class ControlStructureSpacingSniff implements Sniff
         // Add more later
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkTryToken(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -61,12 +55,6 @@ class ControlStructureSpacingSniff implements Sniff
         $this->expectSingleSpaceAfter($phpcsFile, $stackPtr, 'try');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkCatchToken(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -79,13 +67,6 @@ class ControlStructureSpacingSniff implements Sniff
         $this->expectSingleSpaceAfter($phpcsFile, $stackPtr, 'catch');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $tokenName
-     *
-     * @return void
-     */
     protected function expectSingleSpaceBefore(File $phpcsFile, int $stackPtr, string $tokenName): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -112,13 +93,6 @@ class ControlStructureSpacingSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $tokenName
-     *
-     * @return void
-     */
     protected function expectSingleSpaceAfter(File $phpcsFile, int $stackPtr, string $tokenName): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
+++ b/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniff.php
@@ -132,13 +132,6 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param int $previousTokenIndex
-     *
-     * @return bool
-     */
     protected function isSafeToSkipCast(File $phpcsFile, int $stackPtr, int $previousTokenIndex): bool
     {
         $assignmentTokenIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousTokenIndex - 1), null, true);
@@ -166,13 +159,6 @@ class DisallowCloakingCheckSniff extends AbstractSprykerSniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $valueIndex
-     * @param int $lastValueIndex
-     *
-     * @return bool
-     */
     protected function isValidSilencing(File $phpcsFile, int $valueIndex, int $lastValueIndex): bool
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
+++ b/Spryker/Sniffs/ControlStructures/NoInlineAssignmentSniff.php
@@ -55,14 +55,6 @@ class NoInlineAssignmentSniff extends AbstractSprykerSniff
         $phpcsFile->addError('Inline/Conditional assignment not allowed', $stackPtr, 'ConditionalAssignmentNotAllowed');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $startIndex
-     * @param int $endIndex
-     * @param int $indexEqualSign
-     *
-     * @return bool
-     */
     protected function isFixableInlineAssignment(
         File $phpcsFile,
         int $startIndex,
@@ -103,12 +95,6 @@ class NoInlineAssignmentSniff extends AbstractSprykerSniff
         return $hasInlineAssignment;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkMethodCalls(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/DependencyProvider/FacadeNotInBridgeReturnedSniff.php
+++ b/Spryker/Sniffs/DependencyProvider/FacadeNotInBridgeReturnedSniff.php
@@ -45,11 +45,6 @@ class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isProvider(File $phpCsFile): bool
     {
         $className = $this->getClassName($phpCsFile);
@@ -62,11 +57,6 @@ class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
         return ($relevantClassNamePart === $providerName);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isCoreProvider(File $phpCsFile): bool
     {
         $namespace = $this->getNamespace($phpCsFile);
@@ -74,12 +64,6 @@ class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
         return ($namespace === static::NAMESPACE_SPRYKER);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isFacadeNotInBridgeReturned(File $phpCsFile, int $stackPointer): bool
     {
         $tokens = $phpCsFile->getTokens();
@@ -98,8 +82,6 @@ class FacadeNotInBridgeReturnedSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     *
-     * @return string
      */
     protected function parseTokensContent(array $tokens): string
     {

--- a/Spryker/Sniffs/Factory/CreateVsGetMethodsSniff.php
+++ b/Spryker/Sniffs/Factory/CreateVsGetMethodsSniff.php
@@ -59,12 +59,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getMethodName(File $phpCsFile, int $stackPointer): string
     {
         $tokens = $phpCsFile->getTokens();
@@ -74,11 +68,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
         return $methodName;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isFactory(File $phpCsFile): bool
     {
         $className = $this->getClassName($phpCsFile);
@@ -91,11 +80,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
         return (substr($className, -15, -7) === 'Business' || substr($className, -20, -7) === 'Communication');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getClassName(File $phpCsFile): string
     {
         $fileName = $phpCsFile->getFilename();
@@ -108,12 +92,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
         return $className;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getClassMethod(File $phpCsFile, int $stackPointer): string
     {
         $className = $this->getClassName($phpCsFile);
@@ -124,13 +102,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
         return $classMethod;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     * @param string $newMethodName
-     *
-     * @return void
-     */
     protected function correctMethodName(File $phpCsFile, int $stackPointer, string $newMethodName): void
     {
         $phpCsFile->fixer->beginChangeset();
@@ -140,9 +111,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPointer
-     *
-     * @return bool
      */
     protected function containsNew(array $tokens, int $stackPointer): bool
     {
@@ -162,9 +130,6 @@ class CreateVsGetMethodsSniff extends AbstractSprykerSniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPointer
-     *
-     * @return bool
      */
     protected function containsCreateMethod(array $tokens, int $stackPointer): bool
     {

--- a/Spryker/Sniffs/Factory/NoPrivateMethodsSniff.php
+++ b/Spryker/Sniffs/Factory/NoPrivateMethodsSniff.php
@@ -46,12 +46,6 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isMethodPrivate(File $phpCsFile, int $stackPointer): bool
     {
         $privateTokenPointer = $phpCsFile->findFirstOnLine(T_PRIVATE, $stackPointer);
@@ -62,12 +56,6 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getMethodName(File $phpCsFile, int $stackPointer): string
     {
         $tokens = $phpCsFile->getTokens();
@@ -77,11 +65,6 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
         return $methodName;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isFactory(File $phpCsFile): bool
     {
         $className = $this->getClassName($phpCsFile);
@@ -89,11 +72,6 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
         return (substr($className, -7) === 'Factory');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getClassName(File $phpCsFile): string
     {
         $fileName = $phpCsFile->getFilename();
@@ -106,12 +84,6 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
         return $className;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getClassMethod(File $phpCsFile, int $stackPointer): string
     {
         $className = $this->getClassName($phpCsFile);
@@ -122,12 +94,6 @@ class NoPrivateMethodsSniff extends AbstractSprykerSniff
         return $classMethod;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function makePrivateMethodProtected(File $phpCsFile, int $stackPointer): void
     {
         $phpCsFile->fixer->beginChangeset();

--- a/Spryker/Sniffs/Factory/OneNewPerMethodSniff.php
+++ b/Spryker/Sniffs/Factory/OneNewPerMethodSniff.php
@@ -42,11 +42,6 @@ class OneNewPerMethodSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getClassName(File $phpCsFile): string
     {
         $fileName = $phpCsFile->getFilename();
@@ -59,12 +54,6 @@ class OneNewPerMethodSniff extends AbstractSprykerSniff
         return $className;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getMethodName(File $phpCsFile, int $stackPointer): string
     {
         $tokens = $phpCsFile->getTokens();
@@ -74,11 +63,6 @@ class OneNewPerMethodSniff extends AbstractSprykerSniff
         return $methodName;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isFactory(File $phpCsFile): bool
     {
         $className = $this->getClassName($phpCsFile);
@@ -86,12 +70,6 @@ class OneNewPerMethodSniff extends AbstractSprykerSniff
         return (substr($className, -7) === 'Factory');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function hasMoreThenOneNewInMethod(File $phpCsFile, int $stackPointer): bool
     {
         $openPointer = $phpCsFile->findNext(T_OPEN_CURLY_BRACKET, $stackPointer);
@@ -116,12 +94,6 @@ class OneNewPerMethodSniff extends AbstractSprykerSniff
         return ($secondNewPosition !== false);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getClassMethod(File $phpCsFile, int $stackPointer): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
+++ b/Spryker/Sniffs/Formatting/ArrayDeclarationSniff.php
@@ -63,8 +63,6 @@ class ArrayDeclarationSniff implements Sniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being checked.
      * @param int $arrayStart The token that starts the array definition.
      * @param int $arrayEnd The token that ends the array definition.
-     *
-     * @return void
      */
     public function processSingleLineArray(File $phpcsFile, int $arrayStart, int $arrayEnd): void
     {
@@ -112,8 +110,6 @@ class ArrayDeclarationSniff implements Sniff
      * @param int $stackPtr The position of the current token in the stack passed in $tokens.
      * @param int $arrayStart The token that starts the array definition.
      * @param int $arrayEnd The token that ends the array definition.
-     *
-     * @return void
      */
     public function processMultiLineArray(File $phpcsFile, int $stackPtr, int $arrayStart, int $arrayEnd): void
     {

--- a/Spryker/Sniffs/Formatting/MethodSignatureParametersLineBreakMethodSniff.php
+++ b/Spryker/Sniffs/Formatting/MethodSignatureParametersLineBreakMethodSniff.php
@@ -89,12 +89,6 @@ class MethodSignatureParametersLineBreakMethodSniff extends AbstractSprykerSniff
         $this->makeMethodSignatureSingleLine($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function makeMethodSignatureSingleLine(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -127,12 +121,6 @@ class MethodSignatureParametersLineBreakMethodSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function makeMethodSignatureMultiline(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -165,13 +153,6 @@ class MethodSignatureParametersLineBreakMethodSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $fromPosition
-     * @param int $toPosition
-     *
-     * @return void
-     */
     protected function removeEverythingBetweenPositions(File $phpcsFile, int $fromPosition, int $toPosition): void
     {
         for ($i = $fromPosition + 1; $i < $toPosition; $i++) {

--- a/Spryker/Sniffs/Internal/SprykerBridgeSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerBridgeSniff.php
@@ -40,12 +40,6 @@ class SprykerBridgeSniff implements Sniff
         $this->checkBridge($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function checkBridge(File $phpCsFile, int $stackPointer): void
     {
         $index = $stackPointer;
@@ -62,12 +56,6 @@ class SprykerBridgeSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $index
-     *
-     * @return void
-     */
     protected function assertValidConstructor(File $phpCsFile, int $index): void
     {
         $parameters = $phpCsFile->getMethodParameters($index);
@@ -93,12 +81,6 @@ class SprykerBridgeSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $methodIndex
-     *
-     * @return void
-     */
     protected function assertValidDocBlock(File $phpCsFile, int $methodIndex): void
     {
         $docBlockEndIndex = $this->findRelatedDocBlock($phpCsFile, $methodIndex);
@@ -150,9 +132,6 @@ class SprykerBridgeSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
      * @return int|null Stackpointer value of docblock end tag, or null if cannot be found
      */
     protected function findRelatedDocBlock(File $phpCsFile, int $stackPointer): ?int
@@ -172,11 +151,6 @@ class SprykerBridgeSniff implements Sniff
         return null;
     }
 
-    /**
-     * @param string $content
-     *
-     * @return bool
-     */
     protected function isRelevant(string $content): bool
     {
         $whitelist = [

--- a/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerDisallowFunctionsSniff.php
@@ -25,10 +25,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class SprykerDisallowFunctionsSniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const PHP_MIN = '8.2';
+    protected const string PHP_MIN = '8.2';
 
     /**
      * This property can be filled with the current PHP version in use.
@@ -84,12 +81,6 @@ class SprykerDisallowFunctionsSniff extends AbstractSprykerSniff
         $this->checkForbiddenFunctions($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkForbiddenFunctions(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -114,11 +105,6 @@ class SprykerDisallowFunctionsSniff extends AbstractSprykerSniff
         $phpcsFile->addError($error, $stackPtr, 'Invalid');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     *
-     * @return bool
-     */
     protected function isEnabled(File $phpcsFile): bool
     {
         $version = $this->phpVersion;

--- a/Spryker/Sniffs/Internal/SprykerFacadeSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerFacadeSniff.php
@@ -45,11 +45,6 @@ class SprykerFacadeSniff implements Sniff
 
     /**
      * Facades must have a matching interface.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
      */
     protected function checkFacade(File $phpCsFile, int $stackPointer): void
     {
@@ -63,11 +58,6 @@ class SprykerFacadeSniff implements Sniff
 
     /**
      * Facade methods need to appear in its interface (and vice versa)
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
      */
     protected function checkInterface(File $phpCsFile, int $stackPointer): void
     {
@@ -117,12 +107,6 @@ class SprykerFacadeSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isSprykerFacadeApiClass(File $phpCsFile, int $stackPointer): bool
     {
         if (!$this->hasNamespace($phpCsFile, $stackPointer)) {
@@ -142,12 +126,6 @@ class SprykerFacadeSniff implements Sniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function hasNamespace(File $phpCsFile, int $stackPointer): bool
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $stackPointer);
@@ -158,12 +136,6 @@ class SprykerFacadeSniff implements Sniff
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function getNamespace(File $phpCsFile, int $stackPointer): string
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $stackPointer);
@@ -185,12 +157,6 @@ class SprykerFacadeSniff implements Sniff
         return $namespace;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return string
-     */
     protected function findClassOrInterfaceName(File $phpCsFile, int $stackPointer): string
     {
         $classOrInterfaceNamePosition = $phpCsFile->findNext(T_STRING, $stackPointer);
@@ -198,12 +164,6 @@ class SprykerFacadeSniff implements Sniff
         return $phpCsFile->getTokens()[$classOrInterfaceNamePosition]['content'];
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function isFacadeInterface(File $phpCsFile, int $stackPointer): bool
     {
         $namespace = $this->getNamespace($phpCsFile, $stackPointer);

--- a/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerNoDemoshopSniff.php
@@ -50,11 +50,6 @@ class SprykerNoDemoshopSniff extends AbstractSprykerSniff
         $phpcsFile->addError('No internal "project only" code should be merged into Spryker suite/demoshop.', $stackPtr, 'InvalidContent');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return bool
-     */
     protected function isDemoshopCode(File $phpCsFile): bool
     {
         if (static::$isDemoshop !== null) {

--- a/Spryker/Sniffs/Internal/SprykerPreferStaticOverSelfSniff.php
+++ b/Spryker/Sniffs/Internal/SprykerPreferStaticOverSelfSniff.php
@@ -39,12 +39,6 @@ class SprykerPreferStaticOverSelfSniff extends AbstractSprykerSniff
         $this->assertStatic($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
-     */
     protected function assertStatic(File $phpCsFile, int $stackPointer): void
     {
         $tokens = $phpCsFile->getTokens();

--- a/Spryker/Sniffs/MethodAnnotation/ConfigMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/ConfigMethodAnnotationSniff.php
@@ -15,30 +15,16 @@ use Spryker\Sniffs\AbstractSniffs\AbstractMethodAnnotationSniff;
  */
 class ConfigMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 {
-    /**
-     * @return string
-     */
     protected function getMethodName(): string
     {
         return 'getConfig';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getMethodFileAddedName(File $phpCsFile): string
     {
         return $this->getModule($phpCsFile) . 'Config';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
         if ($this->isProvider($phpCsFile)) {
@@ -64,12 +50,6 @@ class ConfigMethodAnnotationSniff extends AbstractMethodAnnotationSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/MethodAnnotation/EntityManagerMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/EntityManagerMethodAnnotationSniff.php
@@ -15,30 +15,16 @@ use Spryker\Sniffs\AbstractSniffs\AbstractMethodAnnotationSniff;
  */
 class EntityManagerMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 {
-    /**
-     * @return string
-     */
     protected function getMethodName(): string
     {
         return 'getEntityManager';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getMethodFileAddedName(File $phpCsFile): string
     {
         return $this->getModule($phpCsFile) . 'EntityManagerInterface';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
         if ($this->isFacade($phpCsFile, $stackPointer)) {
@@ -52,12 +38,6 @@ class EntityManagerMethodAnnotationSniff extends AbstractMethodAnnotationSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/MethodAnnotation/FacadeMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/FacadeMethodAnnotationSniff.php
@@ -15,30 +15,16 @@ use Spryker\Sniffs\AbstractSniffs\AbstractMethodAnnotationSniff;
  */
 class FacadeMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 {
-    /**
-     * @return string
-     */
     protected function getMethodName(): string
     {
         return 'getFacade';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getMethodFileAddedName(File $phpCsFile): string
     {
         return $this->getModule($phpCsFile) . 'FacadeInterface';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
         if ($this->isController($phpCsFile, $stackPointer)) {
@@ -68,12 +54,6 @@ class FacadeMethodAnnotationSniff extends AbstractMethodAnnotationSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/MethodAnnotation/FactoryMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/FactoryMethodAnnotationSniff.php
@@ -15,30 +15,16 @@ use Spryker\Sniffs\AbstractSniffs\AbstractMethodAnnotationSniff;
  */
 class FactoryMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 {
-    /**
-     * @return string
-     */
     protected function getMethodName(): string
     {
         return 'getFactory';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getMethodFileAddedName(File $phpCsFile): string
     {
         return $this->getModule($phpCsFile) . $this->getLayer($phpCsFile) . 'Factory';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
         if ($this->isController($phpCsFile, $stackPointer)) {
@@ -80,12 +66,6 @@ class FactoryMethodAnnotationSniff extends AbstractMethodAnnotationSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/MethodAnnotation/QueryContainerMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/QueryContainerMethodAnnotationSniff.php
@@ -15,41 +15,21 @@ use Spryker\Sniffs\AbstractSniffs\AbstractMethodAnnotationSniff;
  */
 class QueryContainerMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 {
-    /**
-     * @return string
-     */
     protected function getMethodName(): string
     {
         return 'getQueryContainer';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getMethodFileAddedName(File $phpCsFile): string
     {
         return $this->getModule($phpCsFile) . 'QueryContainerInterface';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/MethodAnnotation/RepositoryMethodAnnotationSniff.php
+++ b/Spryker/Sniffs/MethodAnnotation/RepositoryMethodAnnotationSniff.php
@@ -15,30 +15,16 @@ use Spryker\Sniffs\AbstractSniffs\AbstractMethodAnnotationSniff;
  */
 class RepositoryMethodAnnotationSniff extends AbstractMethodAnnotationSniff
 {
-    /**
-     * @return string
-     */
     protected function getMethodName(): string
     {
         return 'getRepository';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     *
-     * @return string
-     */
     protected function getMethodFileAddedName(File $phpCsFile): string
     {
         return $this->getModule($phpCsFile) . 'RepositoryInterface';
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return bool
-     */
     protected function getSnifferIsApplicable(File $phpCsFile, int $stackPointer): bool
     {
         if ($this->isController($phpCsFile, $stackPointer)) {
@@ -68,12 +54,6 @@ class RepositoryMethodAnnotationSniff extends AbstractMethodAnnotationSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param string $namespacePart
-     *
-     * @return string
-     */
     protected function getMethodAnnotationFileName(File $phpCsFile, string $namespacePart): string
     {
         $className = $this->getClassName($phpCsFile);

--- a/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNamespaceSniff.php
@@ -84,10 +84,6 @@ class SprykerNamespaceSniff implements Sniff
      * - src/Namespace/Module/src/Namespace/Layer/Module/File.php
      * - src/Namespace/Module/tests/NamespaceTest/Layer/Module/File.php
      * - src/Namespace/File.php (standard PSR-4)
-     *
-     * @param string $filename
-     *
-     * @return string|null
      */
     protected function extractNamespaceFromPath(string $filename): ?string
     {
@@ -132,10 +128,6 @@ class SprykerNamespaceSniff implements Sniff
 
     /**
      * Removes special directories (like _support, _helpers) from the path that should not be part of the namespace.
-     *
-     * @param string $path
-     *
-     * @return string
      */
     protected function removeSpecialDirectories(string $path): string
     {
@@ -149,10 +141,6 @@ class SprykerNamespaceSniff implements Sniff
 
     /**
      * Removes the current working directory (root) if possible.
-     *
-     * @param string $getFilename
-     *
-     * @return string
      */
     protected function normalizeFilename(string $getFilename): string
     {

--- a/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoCrossNamespaceSniff.php
@@ -18,20 +18,14 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
 {
     use UseStatementsTrait;
 
-    /**
-     * @var string
-     */
-    protected const NAMESPACE_YVES = 'Yves';
+    protected const string NAMESPACE_YVES = 'Yves';
 
-    /**
-     * @var string
-     */
-    protected const NAMESPACE_ZED = 'Zed';
+    protected const string NAMESPACE_ZED = 'Zed';
 
     /**
      * @var array<int, array<string, string>>
      */
-    protected const INVALID_PAIRS = [
+    protected const array INVALID_PAIRS = [
         [
             'from' => self::NAMESPACE_YVES,
             'to' => self::NAMESPACE_ZED,
@@ -77,11 +71,8 @@ class SprykerNoCrossNamespaceSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param array<string, mixed> $useStatement
      * @param string $applicationLayer Zed, Yves, ...
-     *
-     * @return void
      */
     protected function checkUseStatement(File $phpcsFile, array $useStatement, string $applicationLayer): void
     {

--- a/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
+++ b/Spryker/Sniffs/Namespaces/SprykerNoPyzSniff.php
@@ -18,10 +18,7 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
 {
     use UseStatementsTrait;
 
-    /**
-     * @var string
-     */
-    protected const NAMESPACE_PROJECT = 'Pyz';
+    protected const string NAMESPACE_PROJECT = 'Pyz';
 
     /**
      * @inheritDoc
@@ -51,11 +48,6 @@ class SprykerNoPyzSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param string $fullClassName
-     *
-     * @return string
-     */
     protected function extractNamespace(string $fullClassName): string
     {
         $namespaces = explode('\\', $fullClassName, 2);

--- a/Spryker/Sniffs/Namespaces/UseStatementSniff.php
+++ b/Spryker/Sniffs/Namespaces/UseStatementSniff.php
@@ -80,12 +80,6 @@ class UseStatementSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkExtends(File $phpcsFile, int $stackPtr): void
     {
         $extendsIndex = $phpcsFile->findNext([T_EXTENDS], $stackPtr + 1);
@@ -102,11 +96,6 @@ class UseStatementSniff implements Sniff
 
     /**
      * Checks extends, implements.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
      */
     protected function checkUseForClass(File $phpcsFile, int $stackPtr): void
     {
@@ -114,12 +103,6 @@ class UseStatementSniff implements Sniff
         $this->checkImplements($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkImplements(File $phpcsFile, int $stackPtr): void
     {
         $implementsIndex = $phpcsFile->findNext([T_IMPLEMENTS], $stackPtr + 1);
@@ -134,11 +117,7 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param array<string, mixed> $statement
-     * @param int $stackPtr
-     *
-     * @return void
      */
     protected function fixStatement(File $phpcsFile, array $statement, int $stackPtr): void
     {
@@ -178,12 +157,6 @@ class UseStatementSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkUseForNew(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -250,12 +223,6 @@ class UseStatementSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkUseForStatic(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -318,12 +285,6 @@ class UseStatementSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkUseForInstanceOf(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -388,12 +349,6 @@ class UseStatementSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     public function checkUseForCatchOrCallable(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -467,12 +422,6 @@ class UseStatementSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkUseForSignature(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -538,12 +487,6 @@ class UseStatementSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkUseForReturnTypeHint(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -624,12 +567,6 @@ class UseStatementSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkPropertyForInstanceOf(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -691,8 +628,6 @@ class UseStatementSniff implements Sniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
-     *
-     * @return void
      */
     protected function loadStatements(File $phpcsFile): void
     {
@@ -710,10 +645,6 @@ class UseStatementSniff implements Sniff
 
     /**
      * Another sniff takes care of that, we just ignore then.
-     *
-     * @param string $statementContent
-     *
-     * @return bool
      */
     protected function isMultipleUseStatement(string $statementContent): bool
     {
@@ -724,13 +655,6 @@ class UseStatementSniff implements Sniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param string $shortName
-     * @param string $fullName
-     *
-     * @return string|null
-     */
     protected function generateUniqueAlias(File $phpcsFile, string $shortName, string $fullName): ?string
     {
         $alias = $shortName;
@@ -766,12 +690,6 @@ class UseStatementSniff implements Sniff
         return $alias;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param string $fullName
-     *
-     * @return bool
-     */
     protected function isSameVendor(File $phpcsFile, string $fullName): bool
     {
         $namespaceStatement = $this->getNamespaceStatement($phpcsFile);
@@ -784,8 +702,6 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     *
      * @return array<string, array<string, mixed>>
      */
     protected function getUseStatements(File $phpcsFile): array
@@ -858,10 +774,6 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param string $shortName
-     * @param string $fullName
-     *
      * @throws \RuntimeException
      *
      * @return array<string, mixed>
@@ -894,10 +806,7 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param array<string, mixed> $useStatement
-     *
-     * @return void
      */
     protected function insertUseStatement(File $phpcsFile, array $useStatement): void
     {
@@ -918,8 +827,6 @@ class UseStatementSniff implements Sniff
 
     /**
      * @param array<string, mixed> $useStatement
-     *
-     * @return string
      */
     protected function generateUseStatement(array $useStatement): string
     {
@@ -933,11 +840,6 @@ class UseStatementSniff implements Sniff
         return $content;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     *
-     * @return string|null
-     */
     protected function findClassName(File $phpcsFile): ?string
     {
         $index = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT], 0);
@@ -954,9 +856,6 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $extendsStartIndex
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function parseExtends(File $phpcsFile, int $extendsStartIndex): array
@@ -971,9 +870,6 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $implementsStartIndex
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function parseImplements(File $phpcsFile, int $implementsStartIndex): array
@@ -988,10 +884,6 @@ class UseStatementSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $startIndex
-     * @param int $endIndex
-     *
      * @throws \RuntimeException
      *
      * @return array<int, array<string, mixed>>

--- a/Spryker/Sniffs/PHP/DeclareStrictTypesAfterFileDocSniff.php
+++ b/Spryker/Sniffs/PHP/DeclareStrictTypesAfterFileDocSniff.php
@@ -13,20 +13,14 @@ use SlevomatCodingStandard\Helpers\TokenHelper;
 
 class DeclareStrictTypesAfterFileDocSniff implements Sniff
 {
-    /**
-     * @var string
-     */
-    public const CODE_DECLARE_STRICT_TYPES_WRONG_POSITION = 'DeclareStrictTypesWrongPosition';
+    public const string CODE_DECLARE_STRICT_TYPES_WRONG_POSITION = 'DeclareStrictTypesWrongPosition';
 
-    /**
-     * @var string
-     */
-    public const CODE_DECLARE_STRICT_TYPES_MISSING = 'DeclareStrictTypesMissing';
+    public const string CODE_DECLARE_STRICT_TYPES_MISSING = 'DeclareStrictTypesMissing';
 
     /**
      * @var array<int|string>
      */
-    protected const ALLOWED_TOKEN_CODES_BEFORE_FILE_DOC = [
+    protected const array ALLOWED_TOKEN_CODES_BEFORE_FILE_DOC = [
         T_WHITESPACE, T_DECLARE, T_OPEN_PARENTHESIS, T_STRING, T_EQUAL, T_LNUMBER, T_CLOSE_PARENTHESIS, T_SEMICOLON,
     ];
 
@@ -136,9 +130,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
         }
     }
 
-    /**
-     * @return void
-     */
     protected function onBeforeProcess(): void
     {
         $this->linesCountBeforeDeclare = $this->normalizeIntValue($this->linesCountBeforeDeclare);
@@ -148,8 +139,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     *
-     * @return bool
      */
     protected function isScript(array $tokens): bool
     {
@@ -165,9 +154,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $declarePosition
-     *
-     * @return bool
      */
     protected function isDeclareAfterOpenTag(array $tokens, int $declarePosition): bool
     {
@@ -187,9 +173,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $stackPtr
-     *
-     * @return bool
      */
     protected function isFileDocumentation(array $tokens, int $stackPtr): bool
     {
@@ -226,11 +209,7 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param array<int, array<string, mixed>> $tokens
-     * @param int $declareStrictTypeTokenPosition
-     *
-     * @return void
      */
     protected function removeStrictTypeDeclaration(File $phpcsFile, array $tokens, int $declareStrictTypeTokenPosition): void
     {
@@ -270,13 +249,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $declarePointer
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function addStrictTypesDeclaration(File $phpcsFile, int $declarePointer, int $stackPtr): void
     {
         $phpcsFile->fixer->beginChangeset();
@@ -304,8 +276,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
 
     /**
      * @param array<int, array<string, mixed>> $tokens
-     *
-     * @return int|null
      */
     protected function getStrictTypeDeclareTokenPosition(array $tokens): ?int
     {
@@ -325,9 +295,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
         return null;
     }
 
-    /**
-     * @return string
-     */
     protected function getStrictTypeDeclaration(): string
     {
         return sprintf(
@@ -339,8 +306,6 @@ class DeclareStrictTypesAfterFileDocSniff implements Sniff
 
     /**
      * @param mixed $value Int value to normalize
-     *
-     * @return int
      */
     protected function normalizeIntValue($value): int
     {

--- a/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
+++ b/Spryker/Sniffs/PHP/DisallowFunctionsSniff.php
@@ -42,12 +42,6 @@ class DisallowFunctionsSniff implements Sniff
         $this->checkImplodeUsage($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkForbiddenFunctions(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -72,12 +66,6 @@ class DisallowFunctionsSniff implements Sniff
         $phpcsFile->addError($error, $stackPtr, 'LongInvalid');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkImplodeUsage(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -115,13 +103,6 @@ class DisallowFunctionsSniff implements Sniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $openingBrace
-     * @param int $closingBrace
-     *
-     * @return int
-     */
     protected function getArgCount(File $phpcsFile, int $openingBrace, int $closingBrace): int
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/PHP/ExitSniff.php
+++ b/Spryker/Sniffs/PHP/ExitSniff.php
@@ -40,12 +40,6 @@ class ExitSniff implements Sniff
         $this->checkExitUsage($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkExitUsage(File $phpcsFile, int $stackPtr): void
     {
         $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
@@ -71,13 +65,6 @@ class ExitSniff implements Sniff
         $phpcsFile->addError($error, $stackPtr, 'Invalid');
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $before
-     *
-     * @return void
-     */
     protected function fixAlias(File $phpcsFile, int $stackPtr, string $before): void
     {
         $after = static::$aliases[$before];

--- a/Spryker/Sniffs/PHP/NoIsNullSniff.php
+++ b/Spryker/Sniffs/PHP/NoIsNullSniff.php
@@ -144,12 +144,6 @@ class NoIsNullSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return bool
-     */
     protected function leadRequiresBrackets(File $phpcsFile, int $index): bool
     {
         $tokens = $phpcsFile->getTokens();
@@ -169,22 +163,11 @@ class NoIsNullSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param int $index
-     *
-     * @return bool
-     */
     protected function isCast(int $index): bool
     {
         return in_array($index, Tokens::$castTokens);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return int|null
-     */
     protected function findUnnecessaryLeadingComparisonStart(File $phpcsFile, int $index): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -202,12 +185,6 @@ class NoIsNullSniff extends AbstractSprykerSniff
         return $previous;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return int|null
-     */
     protected function findUnnecessaryTrailingComparisonEnd(File $phpcsFile, int $index): ?int
     {
         $tokens = $phpcsFile->getTokens();
@@ -225,12 +202,6 @@ class NoIsNullSniff extends AbstractSprykerSniff
         return $next;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function hasLeadingComparison(File $phpcsFile, int $stackPtr): bool
     {
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
@@ -242,12 +213,6 @@ class NoIsNullSniff extends AbstractSprykerSniff
         return $this->isComparison($phpcsFile, $previous);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function hasTrailingComparison(File $phpcsFile, int $stackPtr): bool
     {
         $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
@@ -259,12 +224,6 @@ class NoIsNullSniff extends AbstractSprykerSniff
         return $this->isComparison($phpcsFile, $next);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return bool
-     */
     protected function isComparison(File $phpcsFile, int $index): bool
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/Spryker/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -15,10 +15,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class PhpSapiConstantSniff implements Sniff
 {
-    /**
-     * @var string
-     */
-    protected const PHP_SAPI = 'PHP_SAPI';
+    protected const string PHP_SAPI = 'PHP_SAPI';
 
     /**
      * @inheritDoc

--- a/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
+++ b/Spryker/Sniffs/PHP/PreferCastOverFunctionSniff.php
@@ -73,15 +73,6 @@ class PreferCastOverFunctionSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $key
-     * @param int $openingBraceIndex
-     * @param int $closingBraceIndex
-     *
-     * @return void
-     */
     protected function fixContent(
         File $phpcsFile,
         int $stackPtr,

--- a/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/Spryker/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -53,12 +53,6 @@ class RemoveFunctionAliasSniff implements Sniff
         $this->checkFixableAliases($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function checkFixableAliases(File $phpcsFile, int $stackPtr): void
     {
         $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];

--- a/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
+++ b/Spryker/Sniffs/Testing/AssertPrimitivesSniff.php
@@ -18,10 +18,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class AssertPrimitivesSniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const METHOD_ASSERT_SAME = 'assertSame';
+    protected const string METHOD_ASSERT_SAME = 'assertSame';
 
     /**
      * @var array<string>
@@ -52,12 +49,6 @@ class AssertPrimitivesSniff extends AbstractSprykerSniff
         $this->assertSameUsage($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function assertSameUsage(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -120,12 +111,6 @@ class AssertPrimitivesSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function isTest(File $phpcsFile, int $stackPtr): bool
     {
         $filename = $phpcsFile->getFilename();

--- a/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
+++ b/Spryker/Sniffs/Testing/ExpectExceptionSniff.php
@@ -18,10 +18,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class ExpectExceptionSniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const METHOD_EXPECT_EXCEPTION = 'expectException';
+    protected const string METHOD_EXPECT_EXCEPTION = 'expectException';
 
     /**
      * @inheritDoc
@@ -43,12 +40,6 @@ class ExpectExceptionSniff extends AbstractSprykerSniff
         $this->assertNoAssertsAfterExpectException($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function assertNoAssertsAfterExpectException(
         File $phpcsFile,
         int $stackPtr
@@ -89,13 +80,6 @@ class ExpectExceptionSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $expectationIndex
-     * @param int $endIndex
-     *
-     * @return void
-     */
     protected function assertNoFollowingAsserts(File $phpcsFile, int $expectationIndex, int $endIndex): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -122,12 +106,6 @@ class ExpectExceptionSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function isTest(File $phpcsFile, int $stackPtr): bool
     {
         $filename = $phpcsFile->getFilename();

--- a/Spryker/Sniffs/Testing/MockSniff.php
+++ b/Spryker/Sniffs/Testing/MockSniff.php
@@ -20,10 +20,7 @@ use Spryker\Sniffs\AbstractSniffs\AbstractSprykerSniff;
  */
 class MockSniff extends AbstractSprykerSniff
 {
-    /**
-     * @var string
-     */
-    protected const MOCK_OBJECT = '\PHPUnit\Framework\MockObject\MockObject';
+    protected const string MOCK_OBJECT = '\PHPUnit\Framework\MockObject\MockObject';
 
     /**
      * @inheritDoc
@@ -50,12 +47,7 @@ class MockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param \SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
      * @param array<string> $docBlockReturnTypes
-     *
-     * @return void
      */
     protected function assertNoReturnTypehint(
         File $phpcsFile,
@@ -75,13 +67,6 @@ class MockSniff extends AbstractSprykerSniff
         $this->removeReturnTypeHint($phpcsFile, $stackPtr, $returnTypeHint);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param \SlevomatCodingStandard\Helpers\TypeHint $returnTypeHint
-     *
-     * @return void
-     */
     protected function removeReturnTypeHint(File $phpcsFile, int $stackPtr, TypeHint $returnTypeHint): void
     {
         $colonPointer = $phpcsFile->findPrevious(T_COLON, $returnTypeHint->getStartPointer(), $stackPtr);
@@ -100,12 +85,7 @@ class MockSniff extends AbstractSprykerSniff
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
      * @param array<string> $docBlockReturnTypes
-     * @param \SlevomatCodingStandard\Helpers\TypeHint|null $returnTypeHint
-     *
-     * @return void
      */
     protected function assertDocBlockReturnAnnotation(
         File $phpcsFile,
@@ -174,13 +154,6 @@ class MockSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param string $returnTypeHint
-     *
-     * @return void
-     */
     protected function addReturnTypeHint(File $phpcsFile, int $stackPtr, string $returnTypeHint): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -200,12 +173,6 @@ class MockSniff extends AbstractSprykerSniff
         $phpcsFile->fixer->endChangeset();
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
-     */
     protected function isTest(File $phpcsFile, int $stackPtr): bool
     {
         $filename = $phpcsFile->getFilename();
@@ -218,8 +185,6 @@ class MockSniff extends AbstractSprykerSniff
 
     /**
      * @param array<string> $docBlockReturnTypes
-     *
-     * @return bool
      */
     protected function hasMockObjectAnnotation(array $docBlockReturnTypes): bool
     {
@@ -234,12 +199,6 @@ class MockSniff extends AbstractSprykerSniff
         return false;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return int|null
-     */
     protected function getDocBlockReturnTypeContentIndex(File $phpcsFile, int $stackPtr): ?int
     {
         $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $stackPtr);

--- a/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -57,13 +57,6 @@ class CommaSpacingSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     * @param int $next
-     *
-     * @return void
-     */
     public function checkNext(File $phpcsFile, int $stackPtr, int $next): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ConcatenationSpacingSniff.php
@@ -84,11 +84,6 @@ class ConcatenationSpacingSniff implements Sniff
 
     /**
      * Adds a single space on the right sight.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return void
      */
     protected function addSpace(File $phpcsFile, int $index): void
     {
@@ -97,11 +92,6 @@ class ConcatenationSpacingSniff implements Sniff
 
     /**
      * Replaces whitespace with a single space.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $index
-     *
-     * @return void
      */
     protected function replaceWithSpace(File $phpcsFile, int $index): void
     {

--- a/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -43,12 +43,6 @@ class EmptyLinesSniff extends AbstractSprykerSniff
         $this->assertMaximumOneEmptyLineBetweenContent($phpcsFile, $stackPtr);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function assertMaximumOneEmptyLineBetweenContent(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -93,13 +93,6 @@ class FunctionSpacingSniff extends AbstractSprykerSniff
         $this->assertNewLineAtTheBeginning($phpCsFile, $stackPointer);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $closingBraceIndex
-     * @param int|null $nextContentIndex
-     *
-     * @return void
-     */
     protected function assertNewLineAtTheEnd(File $phpCsFile, int $closingBraceIndex, ?int $nextContentIndex): void
     {
         $tokens = $phpCsFile->getTokens();
@@ -114,11 +107,6 @@ class FunctionSpacingSniff extends AbstractSprykerSniff
 
     /**
      * Asserts newline at the beginning, including the doc block.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPointer
-     *
-     * @return void
      */
     protected function assertNewLineAtTheBeginning(File $phpCsFile, int $stackPointer): void
     {

--- a/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -51,12 +51,6 @@ class ImplicitCastSpacingSniff implements Sniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return void
-     */
     protected function processIncDec(File $phpcsFile, int $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
+++ b/Spryker/Sniffs/WhiteSpace/MethodSpacingSniff.php
@@ -93,13 +93,6 @@ class MethodSpacingSniff extends AbstractSprykerSniff
         }
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $from
-     * @param int $to
-     *
-     * @return void
-     */
     protected function assertNoAdditionalNewlinesForEmptyBody(File $phpcsFile, int $from, int $to): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/Spryker/Tools/Tokenizer.php
+++ b/Spryker/Tools/Tokenizer.php
@@ -57,9 +57,6 @@ class Tokenizer
         $this->verbose = !empty($argv[2]) && in_array($argv[2], ['--verbose', '-v']);
     }
 
-    /**
-     * @return void
-     */
     public function tokenize(): void
     {
         $res = [];

--- a/Spryker/Traits/BasicsTrait.php
+++ b/Spryker/Traits/BasicsTrait.php
@@ -15,8 +15,6 @@ trait BasicsTrait
     /**
      * @param array<string|int>|string|int $search
      * @param array<string, mixed> $token
-     *
-     * @return bool
      */
     protected function isGivenKind($search, array $token): bool
     {
@@ -33,8 +31,6 @@ trait BasicsTrait
     }
 
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     *
      * @return array<string, mixed>
      */
     protected function getNamespaceStatement(File $phpcsFile): array

--- a/Spryker/Traits/BridgeTrait.php
+++ b/Spryker/Traits/BridgeTrait.php
@@ -12,12 +12,6 @@ use PHP_CodeSniffer\Util\Tokens;
 
 trait BridgeTrait
 {
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $pointer
-     *
-     * @return bool
-     */
     protected function isSprykerBridgeConstructor(File $phpCsFile, int $pointer): bool
     {
         $tokens = $phpCsFile->getTokens();
@@ -45,12 +39,6 @@ trait BridgeTrait
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $pointer
-     *
-     * @return bool
-     */
     protected function isSprykerBridge(File $phpCsFile, int $pointer): bool
     {
         if (!$this->hasNamespace($phpCsFile, $pointer)) {
@@ -70,12 +58,6 @@ trait BridgeTrait
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $pointer
-     *
-     * @return bool
-     */
     protected function hasNamespace(File $phpCsFile, int $pointer): bool
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $pointer);
@@ -86,12 +68,6 @@ trait BridgeTrait
         return true;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $pointer
-     *
-     * @return string
-     */
     protected function getNamespace(File $phpCsFile, int $pointer): string
     {
         $namespacePosition = $phpCsFile->findPrevious(T_NAMESPACE, $pointer);
@@ -111,12 +87,6 @@ trait BridgeTrait
         return $namespace;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $pointer
-     *
-     * @return string
-     */
     protected function findClassOrInterfaceName(File $phpCsFile, int $pointer): string
     {
         $classOrInterfaceNamePosition = $phpCsFile->findNext(T_STRING, $pointer);

--- a/Spryker/Traits/CommentingTrait.php
+++ b/Spryker/Traits/CommentingTrait.php
@@ -30,8 +30,6 @@ trait CommentingTrait
     /**
      * @param string $tagName tag name
      * @param string $tagComment tag comment
-     *
-     * @return \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode
      */
     protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode
     {
@@ -76,9 +74,6 @@ trait CommentingTrait
 
     /**
      * @param array<string> $parts
-     * @param \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode $valueNode
-     *
-     * @return string
      */
     protected function stringifyValueNode(array $parts, PhpDocTagValueNode $valueNode): string
     {
@@ -158,9 +153,6 @@ trait CommentingTrait
      * Allow \Foo\Bar[] or array<\Foo\Bar> to pass as array.
      *
      * @param array<string> $docBlockTypes
-     * @param string $iterableType
-     *
-     * @return bool
      */
     protected function containsTypeArray(array $docBlockTypes, string $iterableType = 'array'): bool
     {
@@ -177,8 +169,6 @@ trait CommentingTrait
      * Checks for ...<...>.
      *
      * @param array<string> $docBlockTypes
-     *
-     * @return bool
      */
     protected function containsIterableSyntax(array $docBlockTypes): bool
     {
@@ -193,8 +183,6 @@ trait CommentingTrait
 
     /**
      * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode|string> $typeNodes type nodes
-     *
-     * @return string
      */
     protected function renderUnionTypes(array $typeNodes): string
     {

--- a/Spryker/Traits/MixedUnionAnnotationTrait.php
+++ b/Spryker/Traits/MixedUnionAnnotationTrait.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Traits;
+
+use PHP_CodeSniffer\Files\File;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use SlevomatCodingStandard\Helpers\Annotation;
+use SlevomatCodingStandard\Helpers\AnnotationHelper;
+use SlevomatCodingStandard\Helpers\DocCommentHelper;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
+
+/**
+ * Slevomat resolves `X|mixed` to plain `mixed`, so an annotation that unions `mixed` with a
+ * generic, array shape or `T[]` compares equal to a native `mixed` hint and is reported — and
+ * auto-fixed away — as useless. That deletes the only place the element type is written down.
+ * Members carrying such an annotation are skipped entirely.
+ */
+trait MixedUnionAnnotationTrait
+{
+    protected function hasDetailedMixedUnionParameterAnnotation(File $phpCsFile, int $functionPointer): bool
+    {
+        foreach (FunctionHelper::getValidParametersAnnotations($phpCsFile, $functionPointer) as $annotation) {
+            if ($this->isDetailedMixedUnionAnnotation($annotation)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function hasDetailedMixedUnionReturnAnnotation(File $phpCsFile, int $functionPointer): bool
+    {
+        $annotation = FunctionHelper::findReturnAnnotation($phpCsFile, $functionPointer);
+
+        return $annotation !== null && $this->isDetailedMixedUnionAnnotation($annotation);
+    }
+
+    protected function hasDetailedMixedUnionVarAnnotation(File $phpCsFile, int $pointer): bool
+    {
+        $docCommentOpenPointer = DocCommentHelper::findDocCommentOpenPointer($phpCsFile, $pointer);
+        if ($docCommentOpenPointer === null) {
+            return false;
+        }
+
+        foreach (AnnotationHelper::getAnnotations($phpCsFile, $docCommentOpenPointer, '@var') as $annotation) {
+            if ($this->isDetailedMixedUnionAnnotation($annotation)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function isDetailedMixedUnionAnnotation(Annotation $annotation): bool
+    {
+        if ($annotation->isInvalid()) {
+            return false;
+        }
+
+        $value = $annotation->getValue();
+        if (
+            !$value instanceof ParamTagValueNode
+            && !$value instanceof ReturnTagValueNode
+            && !$value instanceof VarTagValueNode
+        ) {
+            return false;
+        }
+
+        return $this->isDetailedMixedUnion($value->type);
+    }
+
+    protected function isDetailedMixedUnion(TypeNode $typeNode): bool
+    {
+        if (!$typeNode instanceof UnionTypeNode) {
+            return false;
+        }
+
+        $hasMixed = false;
+        $hasTypeDetail = false;
+
+        foreach ($typeNode->types as $innerTypeNode) {
+            if ($innerTypeNode instanceof IdentifierTypeNode && strtolower($innerTypeNode->name) === 'mixed') {
+                $hasMixed = true;
+
+                continue;
+            }
+
+            if ($this->carriesTypeDetail($innerTypeNode)) {
+                $hasTypeDetail = true;
+            }
+        }
+
+        return $hasMixed && $hasTypeDetail;
+    }
+
+    protected function carriesTypeDetail(TypeNode $typeNode): bool
+    {
+        return $typeNode instanceof GenericTypeNode
+            || $typeNode instanceof ArrayShapeNode
+            || $typeNode instanceof ArrayTypeNode;
+    }
+}

--- a/Spryker/Traits/NamespaceTrait.php
+++ b/Spryker/Traits/NamespaceTrait.php
@@ -16,11 +16,6 @@ trait NamespaceTrait
 {
     /**
      * Checks if this use statement is part of the namespace block.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $stackPtr
-     *
-     * @return bool
      */
     protected function shouldIgnoreUse(File $phpcsFile, int $stackPtr): bool
     {

--- a/Spryker/Traits/SignatureTrait.php
+++ b/Spryker/Traits/SignatureTrait.php
@@ -15,9 +15,6 @@ use PHP_CodeSniffer\Files\File;
 trait SignatureTrait
 {
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpCsFile
-     * @param int $stackPtr
-     *
      * @return array<int, array<string, mixed>>
      */
     protected function getMethodSignature(File $phpCsFile, int $stackPtr): array

--- a/Spryker/Traits/UseStatementsTrait.php
+++ b/Spryker/Traits/UseStatementsTrait.php
@@ -13,8 +13,6 @@ use PHP_CodeSniffer\Util\Tokens;
 trait UseStatementsTrait
 {
     /**
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     *
      * @return array<string, array<string, mixed>>
      */
     protected function getUseStatements(File $phpcsFile): array
@@ -88,11 +86,6 @@ trait UseStatementsTrait
         return $statements;
     }
 
-    /**
-     * @param string $statementContent
-     *
-     * @return bool
-     */
     protected function isMultipleUseStatement(string $statementContent): bool
     {
         if (strpos($statementContent, ',') !== false) {

--- a/SprykerStrict/Sniffs/TypeHints/ParameterTypeHintSniff.php
+++ b/SprykerStrict/Sniffs/TypeHints/ParameterTypeHintSniff.php
@@ -10,10 +10,12 @@ namespace SprykerStrict\Sniffs\TypeHints;
 use PHP_CodeSniffer\Files\File;
 use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff as SlevomatParameterTypeHintSniff;
 use Spryker\Traits\BridgeTrait;
+use Spryker\Traits\MixedUnionAnnotationTrait;
 
 class ParameterTypeHintSniff extends SlevomatParameterTypeHintSniff
 {
     use BridgeTrait;
+    use MixedUnionAnnotationTrait;
 
     /**
      * @inheritDoc
@@ -21,6 +23,10 @@ class ParameterTypeHintSniff extends SlevomatParameterTypeHintSniff
     public function process(File $phpcsFile, $pointer): void
     {
         if ($this->isSprykerBridgeConstructor($phpcsFile, $pointer)) {
+            return;
+        }
+
+        if ($this->hasDetailedMixedUnionParameterAnnotation($phpcsFile, $pointer)) {
             return;
         }
 

--- a/SprykerStrict/Sniffs/TypeHints/PropertyTypeHintSniff.php
+++ b/SprykerStrict/Sniffs/TypeHints/PropertyTypeHintSniff.php
@@ -7,8 +7,23 @@
 
 namespace SprykerStrict\Sniffs\TypeHints;
 
+use PHP_CodeSniffer\Files\File;
 use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff as SlevomatPropertyTypeHintSniff;
+use Spryker\Traits\MixedUnionAnnotationTrait;
 
 class PropertyTypeHintSniff extends SlevomatPropertyTypeHintSniff
 {
+    use MixedUnionAnnotationTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $pointer): void
+    {
+        if ($this->hasDetailedMixedUnionVarAnnotation($phpcsFile, $pointer)) {
+            return;
+        }
+
+        parent::process($phpcsFile, $pointer);
+    }
 }

--- a/SprykerStrict/Sniffs/TypeHints/ReturnTypeHintSniff.php
+++ b/SprykerStrict/Sniffs/TypeHints/ReturnTypeHintSniff.php
@@ -7,8 +7,23 @@
 
 namespace SprykerStrict\Sniffs\TypeHints;
 
+use PHP_CodeSniffer\Files\File;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff as SlevomatReturnTypeHintSniff;
+use Spryker\Traits\MixedUnionAnnotationTrait;
 
 class ReturnTypeHintSniff extends SlevomatReturnTypeHintSniff
 {
+    use MixedUnionAnnotationTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $pointer): void
+    {
+        if ($this->hasDetailedMixedUnionReturnAnnotation($phpcsFile, $pointer)) {
+            return;
+        }
+
+        parent::process($phpcsFile, $pointer);
+    }
 }

--- a/SprykerStrict/ruleset.xml
+++ b/SprykerStrict/ruleset.xml
@@ -11,8 +11,6 @@
 
     <rule ref="SprykerStrict.TypeHints.ParameterTypeHint">
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.UselessAnnotation"/>
-        <exclude name="SprykerStrict.TypeHints.ParameterTypeHint.UselessDocComment"/>
         <properties>
             <property name="enableMixedTypeHint" value="false"/>
             <property name="enableUnionTypeHint" value="false"/>
@@ -21,8 +19,6 @@
     </rule>
     <rule ref="SprykerStrict.TypeHints.ReturnTypeHint">
         <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.UselessAnnotation"/>
-        <exclude name="SprykerStrict.TypeHints.ReturnTypeHint.UselessDocComment"/>
         <properties>
             <property name="enableStaticTypeHint" value="false"/>
             <property name="enableMixedTypeHint" value="false"/>
@@ -33,8 +29,6 @@
     </rule>
     <rule ref="SprykerStrict.TypeHints.PropertyTypeHint">
         <exclude name="SprykerStrict.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SprykerStrict.TypeHints.PropertyTypeHint.UselessAnnotation"/>
-        <exclude name="SprykerStrict.TypeHints.PropertyTypeHint.UselessDocComment"/>
         <properties>
             <property name="enableNativeTypeHint" value="false"/>
             <property name="enableMixedTypeHint" value="false"/>

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "phpstan/phpdoc-parser": "^1.33.0",
         "slevomat/coding-standard": "^8.14.0",
         "squizlabs/php_codesniffer": "^3.6.2"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,50 +27,6 @@
         <exclude name="Spryker.Commenting.DocBlockReturnVoid.ReturnVoidMissing"/>
     </rule>
 
-    <!-- Self-lint only: forbid redundant @param/@return/@var that merely restate the native type.
-         The shipped SprykerStrict.TypeHints.* wrappers exclude UselessAnnotation; here we reference
-         the raw Slevomat sniffs with UselessAnnotation ON to flag (and auto-fix) redundant docblocks,
-         while excluding the Missing*/UselessSuppress/LessSpecific reporting (already covered by the
-         SprykerStrict wrappers) and disabling union/intersection/mixed/native so legitimate narrowing
-         and array-shape docblocks are preserved. -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessSuppress"/>
-        <properties>
-            <property name="enableMixedTypeHint" value="false"/>
-            <property name="enableUnionTypeHint" value="false"/>
-            <property name="enableIntersectionTypeHint" value="false"/>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.LessSpecificNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessSuppress"/>
-        <properties>
-            <property name="enableStaticTypeHint" value="false"/>
-            <property name="enableMixedTypeHint" value="false"/>
-            <property name="enableUnionTypeHint" value="false"/>
-            <property name="enableIntersectionTypeHint" value="false"/>
-            <property name="enableNeverTypeHint" value="false"/>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessSuppress"/>
-        <properties>
-            <property name="enableNativeTypeHint" value="false"/>
-            <property name="enableMixedTypeHint" value="false"/>
-            <property name="enableUnionTypeHint" value="false"/>
-            <property name="enableIntersectionTypeHint" value="false"/>
-        </properties>
-    </rule>
-
     <rule ref="Spryker.Namespaces.SprykerNamespace">
         <properties>
             <property name="namespace" value="Spryker"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="code-sniffer">
     <config name="installed_paths" value="../../spryker/code-sniffer"/>
-    <config name="php_version" value="70300"/>
+    <config name="php_version" value="80300"/>
 
     <arg name="tab-width" value="4"/>
     <arg value="nps"/>
@@ -14,7 +14,62 @@
     <file>docs/</file>
     <file>bin/</file>
 
-    <rule ref="SprykerStrict"/>
+    <rule ref="SprykerStrict">
+        <!-- Self-lint only: this project's own sources use native types on constants, properties
+             and native parameter/return types instead of restating them in docblocks, so the
+             mandatory-docblock requirement is lifted here. The shipped Spryker/SprykerStrict
+             rulesets are unchanged; consumers keep the standard as-is. -->
+        <exclude name="Spryker.Commenting.DocBlock.DocBlockMissing"/>
+        <exclude name="Spryker.Commenting.DocBlock.ReturnVoidMissing"/>
+        <!-- Native return types are still mandated (SprykerStrict.TypeHints.ReturnTypeHint), so a
+             `@return void` docblock only restates the native `: void` and is redundant here. -->
+        <exclude name="Spryker.Commenting.DocBlockReturnVoid.ReturnMissing"/>
+        <exclude name="Spryker.Commenting.DocBlockReturnVoid.ReturnVoidMissing"/>
+    </rule>
+
+    <!-- Self-lint only: forbid redundant @param/@return/@var that merely restate the native type.
+         The shipped SprykerStrict.TypeHints.* wrappers exclude UselessAnnotation; here we reference
+         the raw Slevomat sniffs with UselessAnnotation ON to flag (and auto-fix) redundant docblocks,
+         while excluding the Missing*/UselessSuppress/LessSpecific reporting (already covered by the
+         SprykerStrict wrappers) and disabling union/intersection/mixed/native so legitimate narrowing
+         and array-shape docblocks are preserved. -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessSuppress"/>
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/>
+            <property name="enableUnionTypeHint" value="false"/>
+            <property name="enableIntersectionTypeHint" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.LessSpecificNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessSuppress"/>
+        <properties>
+            <property name="enableStaticTypeHint" value="false"/>
+            <property name="enableMixedTypeHint" value="false"/>
+            <property name="enableUnionTypeHint" value="false"/>
+            <property name="enableIntersectionTypeHint" value="false"/>
+            <property name="enableNeverTypeHint" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessSuppress"/>
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+            <property name="enableMixedTypeHint" value="false"/>
+            <property name="enableUnionTypeHint" value="false"/>
+            <property name="enableIntersectionTypeHint" value="false"/>
+        </properties>
+    </rule>
 
     <rule ref="Spryker.Namespaces.SprykerNamespace">
         <properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,7 @@
         <!-- Self-lint only: this project's own sources use native types on constants, properties
              and native parameter/return types instead of restating them in docblocks, so the
              mandatory-docblock requirement is lifted here. The shipped Spryker/SprykerStrict
-             rulesets are unchanged; consumers keep the standard as-is. -->
+             rulesets keep mandating them; consumers are unaffected. -->
         <exclude name="Spryker.Commenting.DocBlock.DocBlockMissing"/>
         <exclude name="Spryker.Commenting.DocBlock.ReturnVoidMissing"/>
         <!-- Native return types are still mandated (SprykerStrict.TypeHints.ReturnTypeHint), so a

--- a/tests/Spryker/Sniffs/AllSniffTest.php
+++ b/tests/Spryker/Sniffs/AllSniffTest.php
@@ -14,9 +14,6 @@ use Spryker\Test\TestCase;
  */
 class AllSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testAllSniffs(): void
     {
         $before = $this->testFilePath() . 'All' . DS . 'before.php';

--- a/tests/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DisallowArrayTypeHintSyntaxSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DisallowArrayTypeHintSyntaxSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDisallowArrayTypeHintSyntaxSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DisallowArrayTypeHintSyntaxSniff(), 12);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockThrowsFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DisallowArrayTypeHintSyntaxSniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockConstSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockConstSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockConstSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockConstSniff(), 4);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockConstSniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockParamAllowDefaultValueSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockParamAllowDefaultValueSniff(), 4);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockParamAllowDefaultValueSniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockParamArraySniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockParamArraySniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockParamArraySniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockParamArraySniff(), 2);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockParamArraySniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockReturnNullSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockReturnNullSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockReturnNullSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockReturnNullSniff(), 1);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockReturnNullSniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockReturnNullableTypeSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockReturnNullableTypeSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockReturnNullableTypeSniff(), 3);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockReturnNullableTypeSniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockReturnTagSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockReturnTagSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockReturnTagSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockReturnTagSniff(), 1);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockReturnTagSniff());

--- a/tests/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockReturnVoidSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockReturnVoidSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockReturnVoidSniffer(): void
     {
         $this->assertSnifferFindsFixableErrors(new DocBlockReturnVoidSniff(), 3, 3);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockReturnVoidFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockReturnVoidSniff(), 3);

--- a/tests/Spryker/Sniffs/Commenting/DocBlockThrowsSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockThrowsSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockThrowsSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockThrowsSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockThrowsSniff(), 6);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockThrowsFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockThrowsSniff(), 6);

--- a/tests/Spryker/Sniffs/Commenting/DocBlockVarSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/DocBlockVarSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DocBlockVarSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DocBlockVarSniff(), 1);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DocBlockVarSniff());

--- a/tests/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class FullyQualifiedClassNameInDocBlockSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new FullyQualifiedClassNameInDocBlockSniff(), 11);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new FullyQualifiedClassNameInDocBlockSniff());

--- a/tests/Spryker/Sniffs/Commenting/InlineDocBlockSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/InlineDocBlockSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class InlineDocBlockSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new InlineDocBlockSniff(), 1);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new InlineDocBlockSniff());

--- a/tests/Spryker/Sniffs/Commenting/TypeHintSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/TypeHintSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class TypeHintSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testTypeHintSniffer(): void
     {
         $this->assertSnifferFindsErrors(new TypeHintSniff(), 10);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockThrowsFixer(): void
     {
         $this->assertSnifferCanFixErrors(new TypeHintSniff());

--- a/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
+++ b/tests/Spryker/Sniffs/ControlStructures/DisallowCloakingCheckSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DisallowCloakingCheckSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDisallowArrayTypeHintSyntaxSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DisallowCloakingCheckSniff(), 10);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockThrowsFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DisallowCloakingCheckSniff());

--- a/tests/Spryker/Sniffs/Formatting/MethodSignatureParametersLineBreakMethodSniffTest.php
+++ b/tests/Spryker/Sniffs/Formatting/MethodSignatureParametersLineBreakMethodSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class MethodSignatureParametersLineBreakMethodSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testMethodSignatureParametersLineBreakMethodSniffer(): void
     {
         $this->assertSnifferFindsFixableErrors(new MethodSignatureParametersLineBreakMethodSniff(), 7, 7);
     }
 
-    /**
-     * @return void
-     */
     public function testMethodSignatureParametersLineBreakMethodFixer(): void
     {
         $this->assertSnifferCanFixErrors(new MethodSignatureParametersLineBreakMethodSniff());

--- a/tests/Spryker/Sniffs/Internal/SprykerPreferStaticOverSelfSniffTest.php
+++ b/tests/Spryker/Sniffs/Internal/SprykerPreferStaticOverSelfSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class SprykerPreferStaticOverSelfSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new SprykerPreferStaticOverSelfSniff(), 2);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new SprykerPreferStaticOverSelfSniff());

--- a/tests/Spryker/Sniffs/Namespaces/UseStatementSniffTest.php
+++ b/tests/Spryker/Sniffs/Namespaces/UseStatementSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class UseStatementSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDocBlockConstSniffer(): void
     {
         $this->assertSnifferFindsErrors(new UseStatementSniff(), 1);
     }
 
-    /**
-     * @return void
-     */
     public function testDocBlockConstFixer(): void
     {
         $this->assertSnifferCanFixErrors(new UseStatementSniff());

--- a/tests/Spryker/Sniffs/PHP/DeclareStrictTypesAfterFileDocSniffTest.php
+++ b/tests/Spryker/Sniffs/PHP/DeclareStrictTypesAfterFileDocSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class DeclareStrictTypesAfterFileDocSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testDeclareStrictTypesSniffer(): void
     {
         $this->assertSnifferFindsErrors(new DeclareStrictTypesAfterFileDocSniff(), 2);
     }
 
-    /**
-     * @return void
-     */
     public function testEmptyEnclosingLineFixer(): void
     {
         $this->assertSnifferCanFixErrors(new DeclareStrictTypesAfterFileDocSniff());

--- a/tests/Spryker/Sniffs/TypeHints/ParameterTypeHintSniffTest.php
+++ b/tests/Spryker/Sniffs/TypeHints/ParameterTypeHintSniffTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Test\Spryker\Sniffs\TypeHints;
+
+use Spryker\Test\TestCase;
+use SprykerStrict\Sniffs\TypeHints\ParameterTypeHintSniff;
+
+class ParameterTypeHintSniffTest extends TestCase
+{
+    public function testGivenParamAnnotationsRestatingTheNativeTypeHintWhenSniffedThenOnlyThoseAreReported(): void
+    {
+        // Arrange
+        $sniff = new ParameterTypeHintSniff();
+
+        // Act & Assert
+        $this->assertSnifferFindsErrors($sniff, 2);
+    }
+
+    public function testGivenParamMixedUnionsCarryingTypeDetailWhenFixedThenOnlyTheRestatedAnnotationsAreRemoved(): void
+    {
+        // Arrange
+        $sniff = new ParameterTypeHintSniff();
+
+        // Act & Assert
+        $this->assertSnifferCanFixErrors($sniff, 2);
+    }
+}

--- a/tests/Spryker/Sniffs/TypeHints/PropertyTypeHintSniffTest.php
+++ b/tests/Spryker/Sniffs/TypeHints/PropertyTypeHintSniffTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Test\Spryker\Sniffs\TypeHints;
+
+use Spryker\Test\TestCase;
+use SprykerStrict\Sniffs\TypeHints\PropertyTypeHintSniff;
+
+class PropertyTypeHintSniffTest extends TestCase
+{
+    public function testGivenVarAnnotationsRestatingTheNativeTypeHintWhenSniffedThenOnlyThoseAreReported(): void
+    {
+        // Arrange
+        $sniff = new PropertyTypeHintSniff();
+
+        // Act & Assert
+        $this->assertSnifferFindsErrors($sniff, 2);
+    }
+
+    public function testGivenVarMixedUnionsCarryingTypeDetailWhenFixedThenOnlyTheRestatedAnnotationsAreRemoved(): void
+    {
+        // Arrange
+        $sniff = new PropertyTypeHintSniff();
+
+        // Act & Assert
+        $this->assertSnifferCanFixErrors($sniff, 2);
+    }
+}

--- a/tests/Spryker/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
+++ b/tests/Spryker/Sniffs/TypeHints/ReturnTypeHintSniffTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Test\Spryker\Sniffs\TypeHints;
+
+use Spryker\Test\TestCase;
+use SprykerStrict\Sniffs\TypeHints\ReturnTypeHintSniff;
+
+class ReturnTypeHintSniffTest extends TestCase
+{
+    public function testGivenReturnAnnotationsRestatingTheNativeTypeHintWhenSniffedThenOnlyThoseAreReported(): void
+    {
+        // Arrange
+        $sniff = new ReturnTypeHintSniff();
+
+        // Act & Assert
+        $this->assertSnifferFindsErrors($sniff, 2);
+    }
+
+    public function testGivenReturnMixedUnionsCarryingTypeDetailWhenFixedThenOnlyTheRestatedAnnotationsAreRemoved(): void
+    {
+        // Arrange
+        $sniff = new ReturnTypeHintSniff();
+
+        // Act & Assert
+        $this->assertSnifferCanFixErrors($sniff, 2);
+    }
+}

--- a/tests/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniffTest.php
+++ b/tests/Spryker/Sniffs/WhiteSpace/EmptyEnclosingLineSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class EmptyEnclosingLineSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testEmptyEnclosingLineSniffer(): void
     {
         $this->assertSnifferFindsErrors(new EmptyEnclosingLineSniff(), 2);
     }
 
-    /**
-     * @return void
-     */
     public function testEmptyEnclosingLineFixer(): void
     {
         $this->assertSnifferCanFixErrors(new EmptyEnclosingLineSniff());

--- a/tests/Spryker/Sniffs/WhiteSpace/EmptyLinesSniffTest.php
+++ b/tests/Spryker/Sniffs/WhiteSpace/EmptyLinesSniffTest.php
@@ -12,17 +12,11 @@ use Spryker\Test\TestCase;
 
 class EmptyLinesSniffTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testEmptyLinesSniffer(): void
     {
         $this->assertSnifferFindsErrors(new EmptyLinesSniff(), 6);
     }
 
-    /**
-     * @return void
-     */
     public function testEmptyEnclosingLineFixer(): void
     {
         $this->assertSnifferCanFixErrors(new EmptyLinesSniff());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,10 +40,6 @@ class TestCase extends PHPUnitTestCase
     /**
      * This will run code sniffer and assert the number of warnings found.
      *
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     * @param int $warningCount
-     * @param int|null $errorCount
-     *
      * @return array<array>
      */
     protected function assertSnifferFindsWarnings(Sniff $sniffer, int $warningCount, ?int $errorCount = null): array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,21 +23,12 @@ use ReflectionClass;
  */
 class TestCase extends PHPUnitTestCase
 {
-    /**
-     * @var string
-     */
-    protected const FILE_BEFORE = 'before.php';
+    protected const string FILE_BEFORE = 'before.php';
 
-    /**
-     * @var string
-     */
-    protected const FILE_AFTER = 'after.php';
+    protected const string FILE_AFTER = 'after.php';
 
     /**
      * This will run code sniffer
-     *
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     * @param int $errorCount
      *
      * @return array<array>
      */
@@ -49,10 +40,6 @@ class TestCase extends PHPUnitTestCase
     /**
      * This will run code sniffer
      *
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     * @param int|null $errorCount
-     * @param int $fixableErrorCount
-     *
      * @return array<array>
      */
     protected function assertSnifferFindsFixableErrors(Sniff $sniffer, ?int $errorCount, int $fixableErrorCount): array
@@ -62,11 +49,6 @@ class TestCase extends PHPUnitTestCase
 
     /**
      * This will run code sniffer and code fixer.
-     *
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     * @param int|null $fixableErrorCount
-     *
-     * @return void
      */
     protected function assertSnifferCanFixErrors(Sniff $sniffer, ?int $fixableErrorCount = null): void
     {
@@ -74,12 +56,6 @@ class TestCase extends PHPUnitTestCase
     }
 
     /**
-     * @param string $pathBefore
-     * @param string $pathAfter
-     * @param int|null $errorCount
-     * @param int|null $fixableErrorCount
-     * @param bool $fix
-     *
      * @return array<array>
      */
     protected function runFullFixer(
@@ -139,11 +115,6 @@ class TestCase extends PHPUnitTestCase
     }
 
     /**
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     * @param int|null $errorCount
-     * @param int|null $fixableErrorCount
-     * @param bool $fix
-     *
      * @return array<array>
      */
     protected function runFixer(
@@ -191,32 +162,16 @@ class TestCase extends PHPUnitTestCase
         return $errors;
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     *
-     * @return string
-     */
     protected function getDummyFileBefore(Sniff $sniffer): string
     {
         return $this->getDummyFile($sniffer, static::FILE_BEFORE);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     *
-     * @return string
-     */
     protected function getDummyFileAfter(Sniff $sniffer): string
     {
         return $this->getDummyFile($sniffer, static::FILE_AFTER);
     }
 
-    /**
-     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
-     * @param string $fileName
-     *
-     * @return string
-     */
     protected function getDummyFile(Sniff $sniffer, string $fileName): string
     {
         $className = (new ReflectionClass($sniffer))->getShortName();
@@ -230,9 +185,6 @@ class TestCase extends PHPUnitTestCase
         return $file;
     }
 
-    /**
-     * @return string
-     */
     protected function testFilePath(): string
     {
         return implode(DIRECTORY_SEPARATOR, [
@@ -281,8 +233,6 @@ class TestCase extends PHPUnitTestCase
 
     /**
      * @param array<array<array<string|int|bool>>> $errors
-     *
-     * @return string
      */
     protected function getFormattedErrors(array $errors): string
     {

--- a/tests/_data/ParameterTypeHint/after.php
+++ b/tests/_data/ParameterTypeHint/after.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App;
+
+class Foo
+{
+    /**
+     * @param \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed $serviceTransfers
+     */
+    public function keepGeneric(mixed $serviceTransfers): void
+    {
+    }
+
+    /**
+     * @param mixed|array<string>|null $uuids
+     */
+    public function keepArrayGeneric(mixed $uuids): void
+    {
+    }
+
+    /**
+     * @param array{sku: string, quantity: int}|mixed $item
+     */
+    public function keepArrayShape(mixed $item): void
+    {
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\StoreTransfer[]|mixed $storeTransfers
+     */
+    public function keepLegacyArraySyntax(mixed $storeTransfers): void
+    {
+    }
+
+    /**
+     */
+    public function removeRestatedTypeHint(string $sku): void
+    {
+    }
+
+    /**
+     */
+    public function removeMixedUnionWithoutDetail(mixed $value): void
+    {
+    }
+}

--- a/tests/_data/ParameterTypeHint/before.php
+++ b/tests/_data/ParameterTypeHint/before.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App;
+
+class Foo
+{
+    /**
+     * @param \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed $serviceTransfers
+     */
+    public function keepGeneric(mixed $serviceTransfers): void
+    {
+    }
+
+    /**
+     * @param mixed|array<string>|null $uuids
+     */
+    public function keepArrayGeneric(mixed $uuids): void
+    {
+    }
+
+    /**
+     * @param array{sku: string, quantity: int}|mixed $item
+     */
+    public function keepArrayShape(mixed $item): void
+    {
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\StoreTransfer[]|mixed $storeTransfers
+     */
+    public function keepLegacyArraySyntax(mixed $storeTransfers): void
+    {
+    }
+
+    /**
+     * @param string $sku
+     */
+    public function removeRestatedTypeHint(string $sku): void
+    {
+    }
+
+    /**
+     * @param string|mixed $value
+     */
+    public function removeMixedUnionWithoutDetail(mixed $value): void
+    {
+    }
+}

--- a/tests/_data/PropertyTypeHint/after.php
+++ b/tests/_data/PropertyTypeHint/after.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App;
+
+class Foo
+{
+    /**
+     * @var \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed
+     */
+    protected mixed $keptGeneric;
+
+    /**
+     * @var array{sku: string, quantity: int}|mixed
+     */
+    protected mixed $keptArrayShape;
+
+    protected string $restatedTypeHint = '';
+
+    protected mixed $mixedUnionWithoutDetail;
+}

--- a/tests/_data/PropertyTypeHint/before.php
+++ b/tests/_data/PropertyTypeHint/before.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App;
+
+class Foo
+{
+    /**
+     * @var \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed
+     */
+    protected mixed $keptGeneric;
+
+    /**
+     * @var array{sku: string, quantity: int}|mixed
+     */
+    protected mixed $keptArrayShape;
+
+    /**
+     * @var string
+     */
+    protected string $restatedTypeHint = '';
+
+    /**
+     * @var string|mixed
+     */
+    protected mixed $mixedUnionWithoutDetail;
+}

--- a/tests/_data/ReturnTypeHint/after.php
+++ b/tests/_data/ReturnTypeHint/after.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App;
+
+class Foo
+{
+    /**
+     * @return \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed
+     */
+    public function keepGeneric(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * @return array{sku: string, quantity: int}|mixed
+     */
+    public function keepArrayShape(): mixed
+    {
+        return null;
+    }
+
+    /**
+     */
+    public function removeRestatedTypeHint(): string
+    {
+        return '';
+    }
+
+    /**
+     */
+    public function removeMixedUnionWithoutDetail(): mixed
+    {
+        return null;
+    }
+}

--- a/tests/_data/ReturnTypeHint/before.php
+++ b/tests/_data/ReturnTypeHint/before.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+class Foo
+{
+    /**
+     * @return \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed
+     */
+    public function keepGeneric(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * @return array{sku: string, quantity: int}|mixed
+     */
+    public function keepArrayShape(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * @return string
+     */
+    public function removeRestatedTypeHint(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return string|mixed
+     */
+    public function removeMixedUnionWithoutDetail(): mixed
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Enforces the "no redundant docblock" rule in the shipped **`SprykerStrict`** standard: `UselessAnnotation`/`UselessDocComment` are no longer excluded, so `@param`/`@return`/`@var` that merely restate the native type are flagged. Array-shape (`array<...>`, `list<...>`, `array{...}`, `T[]`) and narrowing docblocks remain exempt and preserved.

The repo's own sources are swept clean, and scalar class constants are converted to native typed constants (array constants get a native `array` type, shape docblock kept).

**BC:** the `Spryker` standard is unchanged — only `SprykerStrict` consumers are affected, and every new violation is `phpcbf`-auto-fixable. Typed constants require the PHP floor to move to `>=8.3` (CI matrix and composer floor bumped accordingly).

## Guard: unions with `mixed` keep their generics

Slevomat's `TypeHintHelper::normalize()` collapses *any* union containing `mixed` down to plain `mixed`. So

```php
/**
 * @param \ArrayObject<int, \Generated\Shared\Transfer\ServiceTransfer>|mixed $serviceTransfers
 */
public function transform(mixed $serviceTransfers): array
```

compared equal to the native `mixed` hint and was reported — and auto-fixed away — as useless, deleting the only record of the element type. `array<…>`, `list<…>`, `array{…}` and `T[]` were exposed identically, on all three sniffs. Enabling the codes without a guard would have destroyed documented generics across every consumer; it caught three in [spryker/suite#1012](https://github.com/spryker/suite/pull/1012) before this was found, with 24 more waiting in `Spryker` core.

New `Spryker\Traits\MixedUnionAnnotationTrait`: the `SprykerStrict.TypeHints.{Parameter,Return,Property}TypeHint` sniffs skip a member whose `@param`/`@return`/`@var` unions `mixed` with a `GenericTypeNode`, `ArrayShapeNode` or `ArrayTypeNode`. Annotations that only restate the native hint are still reported and fixed.

Skipping at member level mirrors the existing `isSprykerBridgeConstructor()` early return — Slevomat's `checkUselessAnnotations()` is `private`, so per-annotation hooking is not possible. The precision cost is nil in practice: across suite only 2 of the 30 affected sites sit in multi-parameter functions, and both siblings are fully typed.

Verified against suite: with the flipped ruleset alone, `src/SprykerFeature` reports 3 `UselessAnnotation` errors on the generics; with the guard, 0. The 16 findings remaining across the 19 affected files tree-wide are all genuine (`@return void`, `@var int|null`, `@param int $id`).

Jira: https://spryker.atlassian.net/browse/CC-39568

## Test plan
- `composer cs-check` — green
- `composer test` — green (57 tests, incl. 6 new `{Parameter,Return,Property}TypeHintSniffTest` cases with before/after fixtures)
- `composer stan` — green
- `composer xml` — green
