### PR TITLE
Accept imported attributes, not only fully qualified ones

### DIFF
--- a/Spryker/Sniffs/Commenting/AttributesSniff.php
+++ b/Spryker/Sniffs/Commenting/AttributesSniff.php
@@ -10,12 +10,19 @@ namespace Spryker\Sniffs\Commenting;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use SlevomatCodingStandard\Helpers\UseStatementHelper;
 
 /**
- * Checks that attributes are always `\FQCN`.
+ * Checks that attributes resolve unambiguously: either written as `\FQCN`, or referenced by the
+ * short name of a `use` import. A short name without a matching import silently resolves against
+ * the current namespace, which is what this reports.
  */
 class AttributesSniff implements Sniff
 {
+    protected const string CODE_EXPECTED_FQCN = 'ExpectedFQCN';
+
+    protected const string MESSAGE_EXPECTED_FQCN = 'FQCN or matching `use` import expected for attribute';
+
     /**
      * @inheritDoc
      */
@@ -31,17 +38,103 @@ class AttributesSniff implements Sniff
      */
     public function process(File $phpCsFile, $stackPointer): void
     {
-        $nextIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $stackPointer + 1, null, true);
-        if (!$nextIndex) {
-            return;
+        foreach ($this->getAttributeNameIndexes($phpCsFile, $stackPointer) as $nameIndex) {
+            if ($this->isResolvable($phpCsFile, $nameIndex)) {
+                continue;
+            }
+
+            $phpCsFile->addError(static::MESSAGE_EXPECTED_FQCN, $nameIndex, static::CODE_EXPECTED_FQCN);
+        }
+    }
+
+    /**
+     * One `#[...]` can group several attributes, e.g. `#[Foo, \Bar]`, so every name in the group
+     * has to be collected — not just the first one after the opener.
+     *
+     * @return array<int>
+     */
+    protected function getAttributeNameIndexes(File $phpCsFile, int $stackPointer): array
+    {
+        $tokens = $phpCsFile->getTokens();
+        if (!isset($tokens[$stackPointer]['attribute_closer'])) {
+            return [];
         }
 
+        $closerIndex = $tokens[$stackPointer]['attribute_closer'];
+        $nameIndexes = [];
+        $index = $stackPointer;
+
+        while ($index !== null) {
+            $nameIndex = $phpCsFile->findNext(Tokens::$emptyTokens, $index + 1, $closerIndex, true);
+            if ($nameIndex === false) {
+                break;
+            }
+
+            $nameIndexes[] = $nameIndex;
+            $index = $this->findNextAttributeSeparator($phpCsFile, $nameIndex, $closerIndex);
+        }
+
+        return $nameIndexes;
+    }
+
+    /**
+     * The comma that ends one attribute of a group. Argument lists are skipped whole, so a comma
+     * between two arguments does not read as the start of the next attribute.
+     *
+     * @return int|null
+     */
+    protected function findNextAttributeSeparator(File $phpCsFile, int $nameIndex, int $closerIndex): ?int
+    {
         $tokens = $phpCsFile->getTokens();
 
-        if ($tokens[$nextIndex]['code'] === T_NS_SEPARATOR) {
-            return;
+        for ($index = $nameIndex; $index < $closerIndex; $index++) {
+            if ($tokens[$index]['code'] === T_OPEN_PARENTHESIS) {
+                $index = $tokens[$index]['parenthesis_closer'];
+
+                continue;
+            }
+
+            if ($tokens[$index]['code'] === T_COMMA) {
+                return $index;
+            }
         }
 
-        $phpCsFile->addError('FQCN expected for attribute', $nextIndex, 'ExpectedFQCN');
+        return null;
+    }
+
+    protected function isResolvable(File $phpCsFile, int $nameIndex): bool
+    {
+        $tokens = $phpCsFile->getTokens();
+
+        if ($tokens[$nameIndex]['code'] === T_NS_SEPARATOR) {
+            return true;
+        }
+
+        if ($tokens[$nameIndex]['code'] !== T_STRING) {
+            return true;
+        }
+
+        return $this->isImported($phpCsFile, $nameIndex, $tokens[$nameIndex]['content']);
+    }
+
+    /**
+     * A partially qualified attribute such as `#[Attr\Covers]` resolves through the import of its
+     * first segment, so only that segment is looked up.
+     *
+     * @return bool
+     */
+    protected function isImported(File $phpCsFile, int $nameIndex, string $name): bool
+    {
+        foreach (UseStatementHelper::getUseStatementsForPointer($phpCsFile, $nameIndex) as $useStatement) {
+            if (!$useStatement->isClass()) {
+                continue;
+            }
+
+            if (strtolower($useStatement->getNameAsReferencedInFile()) === strtolower($name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Spryker/Sniffs/Commenting/AttributesSniffTest.php
+++ b/tests/Spryker/Sniffs/Commenting/AttributesSniffTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Spryker\Test\Spryker\Sniffs\Commenting;
+
+use Spryker\Sniffs\Commenting\AttributesSniff;
+use Spryker\Test\TestCase;
+
+class AttributesSniffTest extends TestCase
+{
+    /**
+     * @var int
+     */
+    protected const EXPECTED_ERROR_COUNT = 5;
+
+    /**
+     * @return void
+     */
+    public function testAttributesSniffer(): void
+    {
+        $errors = $this->assertSnifferFindsErrors(new AttributesSniff(), static::EXPECTED_ERROR_COUNT);
+
+        $this->assertSame(
+            [40, 45, 50, 57, 62],
+            array_keys($errors),
+            'Only the attributes that are neither fully qualified nor imported should be reported.',
+        );
+    }
+}

--- a/tests/_data/Attributes/before.php
+++ b/tests/_data/Attributes/before.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Demo;
+
+use App\Attr;
+use App\Attr\Covers;
+use App\Attr\Other as Aliased;
+use function App\Attr\helper;
+
+#[\App\Attr\Covers('fully qualified')]
+class FullyQualified
+{
+}
+
+#[Covers('imported short name')]
+class Imported
+{
+}
+
+#[Attr\Covers('partially qualified through the imported first segment')]
+class PartiallyQualified
+{
+}
+
+#[Aliased('aliased import')]
+class AliasedImport
+{
+}
+
+#[covers('import lookup is case insensitive')]
+class DifferentCase
+{
+}
+
+#[Covers('grouped'), \App\Attr\Other('grouped')]
+class GroupedResolvable
+{
+}
+
+#[\App\Attr\Covers('grouped'), Missing('grouped')]
+class GroupedWithUnimported
+{
+}
+
+#[Missing('no import anywhere')]
+class Unimported
+{
+}
+
+#[Covers('a', 'b'), Missing('c', 'd')]
+class ArgumentCommasAreNotSeparators
+{
+}
+
+class Members
+{
+    #[Covers('resolvable')] #[Missing('unimported')]
+    public function twoAttributesOnOneLine(): void
+    {
+    }
+
+    #[helper('a function import does not resolve a class')]
+    public function functionImport(): void
+    {
+    }
+}


### PR DESCRIPTION
`Spryker.Commenting.Attributes.ExpectedFQCN` required every attribute to be written as `\FQCN`. That rules out the ordinary PHP idiom of importing an attribute and referencing it by short name — how PHPUnit, Symfony and API Platform attributes are written everywhere else.

The sniff now checks that an attribute resolves **unambiguously**: fully qualified, or a short name backed by a matching `use` import. A short name with no import stays an error — that one silently resolves against the current namespace, which is the case actually worth reporting.

```php
#[\App\Attr\Covers('a')]   // ok
use App\Attr\Covers;
#[Covers('b')]             // ok (new)
#[Missing('c')]            // error - resolves to App\Demo\Missing
```

Aliases, partially qualified names (`#[Attr\Covers]` via `use App\Attr;`) and casing are handled through `UseStatementHelper`, filtered to class imports.

### Why not leave it to project rulesets

`spryker/development` already excludes this rule wholesale for core-module development (`ruleset.xml`, `rulesetStrict.xml`), so today it only applies to project code. Projects that want the imported form have to add an exclusion of their own and every new project has to rediscover that. Fixing the rule removes the need for any of it.

### Two fixes that come with it

- **Grouped attributes were never checked.** `process()` only looked at the first token after `#[`, so the second attribute in `#[\Foo, Bar]` was invisible to the sniff. The whole group is walked now, skipping argument lists so a comma between two arguments does not read as the start of the next attribute.
- **The sniff had no test.** Added one, with a fixture covering fully qualified, imported, partially qualified, aliased, differently cased, grouped, and unimported attributes, plus a `use function` import that must not satisfy a class lookup.

No fixer: for the remaining error case the only semantics-preserving rewrite is `#[Bare]` → `#[\Current\Namespace\Bare]`, which in a namespaced file usually cements a reference to a class that does not exist.

The error code stays `ExpectedFQCN`, so existing project exclusions keep working.

### Verification

Repo: `phpunit` 52 tests green, `phpcs` and `phpstan` clean.

Against a Spryker project (suite), with the same config each time and the project-level exclusion removed:

| | Result |
|---|---|
| Current sniff | 35 errors across 5 files |
| This branch | 0 errors |
| This branch, full project scope (2589 files) | 0 errors |

The full-scope run is the regression check for the grouped-attribute fix, since those were previously unchecked.
